### PR TITLE
Improve README and return prime highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,33 @@
 
 🄰🄰 Hebrew Isopsephy – reproducible code and data for numeric-semantic analysis of the Hebrew Bible (isopsephy, digital-root tools, null-model tests).
 
+## Overview
+
+AlephEfes provides tools for exploring **Aleph-Code** (קוד-אלף), a numerological framework where Hebrew letters map to values 0–21. The system implements a three-layer calculation (units, tens and hundreds) using Δ9 digital-root closure. This approach keeps the digital root constant across layers, enabling systematic analysis of Hebrew texts.
+
+The repository includes an interactive calculator demonstrating the method, as well as code and data for further experiments.
+
+### Key Features
+
+- **Zero-based letter mapping** – א=0, ב=1, ג=2 … ת=21
+- **Multi-layer sums** – units, tens (Δ9 adjustment) and hundreds (with special multipliers for ש and ת)
+- **Digital root computation** – consistent across layers via Δ9 closure
+- **Prime detection** – primes highlighted in green with a diamond marker
+- **Line and text summaries** – breakdown by line with cumulative totals
+
 ## Aleph Code Calculator
 
-A simple browser-based React application is included in this repository to explore the Aleph-Code numerology system. The app lives in `index.html` and can be opened directly in any modern browser.
+A browser-based React application lives in `index.html`. It can be opened directly in any modern browser or served locally.
 
 ### Running Locally
 
 1. Ensure you have Python installed.
-2. From the repository directory start a small HTTP server:
-   ```bash
-   python3 -m http.server
-   ```
+2. Start a small HTTP server from the repository directory:
+
+```bash
+python3 -m http.server
+```
+
 3. Open [http://localhost:8000/index.html](http://localhost:8000/index.html) in your browser.
 
 The application loads React, ReactDOM, Babel and TailwindCSS from public CDNs, so an internet connection is required when first opening the page.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ The repository includes an interactive calculator demonstrating the method, as w
 ### Key Features
 
 - **Zero-based letter mapping** – א=0, ב=1, ג=2 … ת=21
-- **Multi-layer sums** – units, tens (Δ9 adjustment) and hundreds (with special multipliers for ש and ת)
+- **Multi-layer sums** – units, tens (Δ9 adjustment) and hundreds with special multipliers for ש and ת
 - **Digital root computation** – consistent across layers via Δ9 closure
 - **Prime detection** – primes highlighted in green with a diamond marker
 - **Line and text summaries** – breakdown by line with cumulative totals
+- **Prime summary table** – lists all prime totals encountered
+- **Detailed letter breakdown** for each word
 
 ## Aleph Code Calculator
 

--- a/index.html
+++ b/index.html
@@ -120,14 +120,14 @@
         // --- Render Functions ---
 
         const PrimeCell = ({ value, isPrimeFlag }) => (
-            <td className={`px-4 py-3 text-center tabular-nums ${isPrimeFlag ? 'text-emerald-500 font-bold' : 'text-gray-700'}`}>
+            <td className={`px-4 py-3 text-center tabular-nums ${isPrimeFlag ? 'text-green-600 font-bold' : 'text-gray-700'}` }>
                 {value}
-                {isPrimeFlag && <span className="ml-1 text-emerald-500" title="ראשוני">♢</span>}
+                {isPrimeFlag && <span className="ml-1 text-green-600" title="ראשוני">♢</span>}
             </td>
         );
-        
+
         const TotalNumberDisplay = ({ value, isPrimeFlag }) => (
-             <p className={`text-3xl font-bold ${isPrimeFlag ? 'text-emerald-400' : ''}`}>
+             <p className={`text-3xl font-bold ${isPrimeFlag ? 'text-green-500' : ''}`}>
                 {value}
                 {isPrimeFlag && <span className="ml-2 text-xl">♢</span>}
             </p>
@@ -219,7 +219,7 @@
                         <div className="bg-white p-4 sm:p-6 rounded-xl shadow-sm border border-gray-200 mt-8">
                             <h2 className="text-2xl font-bold text-gray-800 mb-2 text-center">סיכום ראשוניים מסכומי השורות</h2>
                             <p className="text-center text-gray-600 mb-4">
-                                בסך הכל נמצאו <span className="font-bold text-emerald-600">{results.primeSummary.length}</span> ערכים ראשוניים בסכומי השורות.
+                                בסך הכל נמצאו <span className="font-bold text-green-600">{results.primeSummary.length}</span> ערכים ראשוניים בסכומי השורות.
                             </p>
                             <div className="overflow-x-auto max-w-lg mx-auto">
                                 <table className="min-w-full bg-white">
@@ -234,7 +234,7 @@
                                         {results.primeSummary.map((primeInfo, index) => (
                                             <tr key={index} className="hover:bg-gray-50">
                                                 <td className="px-4 py-3 text-center text-gray-700">{primeInfo.line}</td>
-                                                <td className="px-4 py-3 text-center font-bold text-emerald-600 tabular-nums">{primeInfo.value}</td>
+                                                <td className="px-4 py-3 text-center font-bold text-green-600 tabular-nums">{primeInfo.value}</td>
                                                 <td className="px-4 py-3 text-center text-gray-700">{primeInfo.layer}</td>
                                             </tr>
                                         ))}


### PR DESCRIPTION
## Summary
- restore green highlighting for prime values in the calculator
- note green prime highlights in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879603e19c88323b401cf58eab5605f