### PR TITLE
chore: add CI + quality gates, Tailwind migration helpers, and centralize core engine usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run quality gates
+        run: npm run check

--- a/docs/dependency-access-for-agent.md
+++ b/docs/dependency-access-for-agent.md
@@ -1,0 +1,182 @@
+# How to provide dependency access in this environment
+
+If you want me to complete package-dependent tasks (like build-time Tailwind migration), the environment needs outbound access for package/binary downloads.
+
+## What is currently failing
+
+- `npm install -D tailwindcss postcss autoprefixer` returns HTTP 403.
+- Downloading Tailwind standalone binary from GitHub releases also returns HTTP 403.
+
+That means installs are blocked by network/security policy, not by project code.
+
+## Fastest ways to unblock
+
+### If you're not in an enterprise environment (most likely your case)
+
+Usually this is caused by local npm/proxy config, VPN, or ISP/network filtering. Try these exact steps:
+
+0. Make sure you are in the repository root (the folder that actually contains `scripts/`):
+```powershell
+cd C:\Users\edeyo\AlephEfes
+dir
+```
+You should see folders like `scripts`, `src`, `tests`, and files like `package.json`.
+If `scripts` is missing entirely, your local checkout is behind this branch. Run:
+```powershell
+git fetch --all
+git pull
+```
+Then check again:
+```powershell
+dir
+```
+If `git pull` is blocked by local changes/untracked files, follow `docs/pull-troubleshooting.md`.
+
+1. Check whether npm is pointed to the public registry:
+```bash
+npm config get registry
+```
+It should print:
+```text
+https://registry.npmjs.org/
+```
+
+2. If not, set it explicitly:
+```bash
+npm config set registry https://registry.npmjs.org/
+```
+
+3. Remove accidental proxy settings:
+```bash
+npm config delete proxy
+npm config delete https-proxy
+npm config delete http-proxy
+```
+
+4. If you use a VPN/ad-block/DNS filter, temporarily disable it and retry.
+
+5. Clear npm cache and retry:
+```bash
+npm cache clean --force
+npm install -D tailwindcss postcss autoprefixer
+```
+
+6. If it still fails, test from a different network (phone hotspot is a quick test).
+
+7. If you still see npm warnings about `http-proxy`/`https-proxy`, your environment may be injecting proxy variables. Check with:
+```bash
+npm config list -l | grep -E "proxy|registry"
+```
+If proxies are injected but blocked by policy, package access can still fail with 403/ENETUNREACH until that proxy policy is fixed.
+
+On Windows where `grep` is unavailable, use one of these:
+
+**PowerShell:**
+```powershell
+npm config list -l | Select-String -Pattern "proxy|registry"
+```
+
+**cmd.exe (`findstr`):**
+```bat
+npm config list -l | findstr /R /C:"proxy" /C:"registry"
+```
+
+If your output looks like this (proxy null + registry npmjs), npm config is likely fine:
+```text
+https-proxy = null
+proxy = null
+registry = "https://registry.npmjs.org/"
+```
+In that case, the remaining issue is usually network-level blocking (ISP/router/corporate DNS/filtering/AV/VPN), not npm config.
+
+### Option A (best): allow npm registry access
+Allow this environment to reach:
+- `https://registry.npmjs.org`
+- Any CDN endpoints required by npm tarballs (if your policy uses mirrors)
+
+Also ensure no policy blocks packages by name (`tailwindcss`, `postcss`, `autoprefixer`).
+
+### Option B: provide an approved internal registry mirror
+If direct npmjs is not allowed, configure npm to an internal mirror that contains required packages.
+
+Example:
+```bash
+npm config set registry https://<your-internal-registry>
+```
+
+Then verify with:
+```bash
+npm view tailwindcss version
+npm view postcss version
+npm view autoprefixer version
+```
+
+### Option C: pre-seed dependencies in the repo
+If network cannot be opened, you can provide:
+- Updated `package.json` + `package-lock.json` with required deps already resolved.
+- Or vendored tarballs + an `.npmrc` pointing installs to local file paths.
+
+### Option D: prebuild assets externally
+As a temporary workaround, you can generate Tailwind build artifacts externally and commit them; I can then wire them into the app and CI.
+
+## Recommended verification checklist
+
+Run these in the same environment before asking me to continue migration:
+
+```bash
+npm ping
+npm view tailwindcss version
+npm install -D tailwindcss postcss autoprefixer
+```
+
+If config is clean but install still fails, run these extra checks:
+```bash
+npm ping
+npm view tailwindcss version
+nslookup registry.npmjs.org
+```
+
+On Windows CMD:
+```bat
+npm ping
+npm view tailwindcss version
+nslookup registry.npmjs.org
+```
+
+If all succeed, I can finish the build-time migration in one pass.
+
+If these checks succeed on your machine but not in the agent runtime, run:
+```powershell
+node .\scripts\complete-tailwind-migration.mjs
+```
+or:
+```powershell
+cd C:\Users\edeyo\AlephEfes
+powershell -ExecutionPolicy Bypass -File .\scripts\complete-tailwind-migration.ps1
+```
+This applies the full migration steps locally (install deps, write Tailwind/PostCSS configs, add CSS entry import, remove CDN script refs, and run `npm run check`).
+
+If you are **not** in the repo root, pass the full path instead:
+```powershell
+powershell -ExecutionPolicy Bypass -File "C:\Users\edeyo\AlephEfes\scripts\complete-tailwind-migration.ps1"
+```
+
+Quick existence check:
+```powershell
+Test-Path "C:\Users\edeyo\AlephEfes\scripts\complete-tailwind-migration.ps1"
+```
+
+Windows CMD helper (same behavior, less typing):
+```bat
+C:\Users\edeyo\AlephEfes\scripts\complete-tailwind-migration.cmd
+```
+
+If you still have parser errors from an older PowerShell helper, use the Node entrypoint directly (`complete-tailwind-migration.mjs`) as shown above.
+
+## Once access is enabled, what I will do next
+
+1. Install Tailwind/PostCSS deps.
+2. Add `tailwind.config.js` + `postcss.config.js`.
+3. Add Tailwind source CSS and import in `src/main.jsx`.
+4. Remove `https://cdn.tailwindcss.com` and runtime config file usage.
+5. Keep `npm run check` and CI green.

--- a/docs/pull-troubleshooting.md
+++ b/docs/pull-troubleshooting.md
@@ -1,0 +1,67 @@
+# Git pull troubleshooting for local changes/untracked files
+
+If `git pull` fails with messages like:
+
+- `Your local changes to the following files would be overwritten by merge`
+- `The following untracked working tree files would be overwritten by merge`
+
+then your local working tree must be cleaned/stashed first.
+
+## Safe path (recommended)
+
+Run from repo root:
+
+```bash
+git status
+```
+
+### Option A — keep your local work, then pull
+
+```bash
+git add -A
+git commit -m "wip: save local changes before pull"
+git pull
+```
+
+If you don't want a commit yet:
+
+```bash
+git stash push -u -m "wip before pull"
+git pull
+git stash pop
+```
+
+### Option B — discard local changes and align to remote branch
+
+⚠️ This deletes local uncommitted changes.
+
+```bash
+git reset --hard
+git clean -fd
+git pull
+```
+
+## For your specific output
+
+Your pull is blocked by:
+
+- modified tracked file: `package.json`
+- untracked file: `docs/repo-investigation-2026-04-09.md`
+
+So run one of the workflows above first, then pull again.
+
+## If `git pull` says "Already up to date" but you still don't have expected files
+
+You may be on `main` while fixes exist on a different branch (for example a `codex/...` branch).
+
+Check remote branches:
+```bash
+git branch -r
+```
+
+Switch to the expected branch (example):
+```bash
+git switch -c codex-fixes origin/codex/investigate-repo-and-suggest-improvements-91qydf
+```
+
+Then verify the script content again.

--- a/docs/repo-investigation-2026-04-09.md
+++ b/docs/repo-investigation-2026-04-09.md
@@ -1,0 +1,173 @@
+# Repository investigation (2026-04-09)
+
+## Executive summary
+
+The repository is healthy in that tests and production build both pass, but it has medium-term maintainability and delivery risks that are fixable with incremental refactors.
+
+Top priorities:
+1. **Eliminate duplicated core-analysis logic between `App.jsx` and `analysisCore.js`.**
+2. **Split the 3.5k-line `App.jsx` into focused modules/components.**
+3. **Replace CDN Tailwind in `index.html` with a build-time Tailwind pipeline.**
+4. **Add static quality gates (lint/format/type-check) to CI and local scripts.**
+5. **Strengthen resilience around worker + fallback behavior and add perf regression checks.**
+
+---
+
+## What I reviewed
+
+- Runtime/build metadata and scripts (`package.json`).
+- App shell and styling bootstrap (`index.html`, `src/main.jsx`).
+- Core numeric engine (`src/core/analysisCore.js`).
+- UI/state implementation (`src/App.jsx`, `src/state/appReducer.js`, `src/components/VirtualizedList.jsx`).
+- Worker offloading path (`src/workers/coreResults.worker.js`).
+- Existing automated tests under `tests/`.
+
+---
+
+## Strengths observed
+
+- **Fast feedback loop exists already**: unit tests (`node --test`) and production bundling (`vite build`) both pass.
+- **Good separation intent** is visible (`core/`, `state/`, `workers/`, `components/`), even though not fully realized in the main app file yet.
+- **Domain logic has direct tests** for core calculators, query semantics, reducer transitions, and formatting helpers.
+- **Worker path exists** for heavy analysis and main-thread fallback is implemented.
+
+---
+
+## Key improvement opportunities
+
+### 1) Remove duplicated analysis engine code (highest impact)
+
+`src/App.jsx` duplicates large portions of the logic that also lives in `src/core/analysisCore.js` (prime sieve, layer matching, value tables, input normalization, word computation, and full `computeCoreResults`).
+
+Why this matters:
+- Bug fixes can silently diverge between two engines.
+- Test coverage mostly targets `core/*` modules, so duplicated app-local logic can drift untested.
+- It increases bundle size and cognitive load for contributors.
+
+Suggested plan:
+- Make `analysisCore.js` the **single source of truth**.
+- In `App.jsx`, replace duplicated helpers with imports from `core/*`.
+- Add one snapshot/contract test to ensure worker results and direct-call results stay identical for the same input/mode.
+
+Effort: **M** (1-2 focused PRs)
+
+---
+
+### 2) Decompose `App.jsx` (3,531 LOC) into feature modules
+
+Current file size makes safe change velocity hard.
+
+Suggested split:
+- `src/features/lines/*`
+- `src/features/clusters/*`
+- `src/features/hotWords/*`
+- `src/hooks/useCoreResultsWorker.js`
+- `src/hooks/useThemeSync.js`
+- `src/lib/visibility.js` (layer/prime visibility rules)
+
+Refactor strategy:
+- Move pure helpers first (no behavior change).
+- Extract presentational sections next.
+- Keep reducer/actions stable while moving call sites.
+- Add shallow render smoke tests for each extracted feature panel.
+
+Effort: **L** (staged across several small PRs)
+
+---
+
+### 3) Move Tailwind from CDN to build-time pipeline
+
+`index.html` currently loads Tailwind from CDN (`https://cdn.tailwindcss.com`).
+
+Risks:
+- Runtime dependency on external network/CDN availability.
+- Less deterministic builds and harder CSP hardening.
+- Missed benefits of purge/minification and class analysis.
+
+Suggested plan:
+- Add `tailwindcss`, `postcss`, `autoprefixer`.
+- Generate `tailwind.config.js` and CSS entry.
+- Keep dark-mode class strategy (`darkMode: 'class'`) as currently used.
+
+Effort: **S/M**
+
+---
+
+### 4) Add quality gates beyond tests
+
+Current scripts include `test`, `build`, and `check`, but no linting or formatting checks.
+
+Suggested additions:
+- `eslint` + `eslint-plugin-react` (+ hooks rules).
+- `prettier` and optional `lint-staged` for pre-commit.
+- Optional TypeScript migration plan (or `// @ts-check` + JSDoc as an intermediate step).
+
+Minimum useful CI gate:
+- `npm run lint`
+- `npm test`
+- `npm run build`
+
+Effort: **S**
+
+---
+
+### 5) Improve worker/fallback observability and performance safety
+
+The app correctly creates a worker and falls back to main-thread compute when unavailable, but there is no explicit telemetry/perf budget.
+
+Suggested enhancements:
+- Track analysis latency percentile (`p50/p95`) by text size bucket.
+- Log worker failures and fallback rate (dev-only or optional diagnostics panel).
+- Add a perf regression benchmark for representative inputs (small/medium/large corpora).
+
+Effort: **S/M**
+
+---
+
+### 6) Documentation cleanup and contributor UX
+
+README contains repeated run instructions and mixes product usage, long research narrative, and setup details.
+
+Suggested cleanup:
+- Keep README concise: purpose, install, run, test, architecture map.
+- Move long-form research narrative to `docs/research/`.
+- Add `CONTRIBUTING.md` (branching, commit style, test expectations).
+
+Effort: **S**
+
+---
+
+## Prioritized roadmap (suggested)
+
+### Phase 1 (quick wins, 1 week)
+- Add lint/format scripts and CI check workflow.
+- README simplification + CONTRIBUTING guide.
+- Add one parity test: `App` path vs `analysisCore` results.
+
+### Phase 2 (stability, 1-2 weeks)
+- Consolidate all analysis helpers into `core/` modules.
+- Remove duplicated logic from `App.jsx`.
+- Add worker diagnostics and fallback counters.
+
+### Phase 3 (maintainability/perf, 2-4 weeks)
+- Break `App.jsx` into feature modules/hooks.
+- Adopt build-time Tailwind pipeline.
+- Introduce perf benchmark job and bundle-size budget tracking.
+
+---
+
+## Suggested first implementation PR
+
+**Title**: "refactor: make `analysisCore` the single compute source"
+
+Scope:
+- Import and use `computeCoreResults` + normalization helpers from `src/core/analysisCore.js` in app runtime paths.
+- Remove duplicated helper implementations from `App.jsx` where safe.
+- Add parity tests for worker and direct compute consistency.
+- No UI changes.
+
+Success criteria:
+- Existing tests pass.
+- Build output remains healthy.
+- Functional behavior unchanged for representative Hebrew inputs.
+

--- a/docs/repo-investigation-status-2026-04-09.md
+++ b/docs/repo-investigation-status-2026-04-09.md
@@ -1,0 +1,44 @@
+# Repo investigation execution status (2026-04-09)
+
+This checklist tracks implementation status against the key actions from `docs/repo-investigation-2026-04-09.md` (excluding README work by request).
+
+## 1) Remove duplicated analysis logic between `App.jsx` and `analysisCore.js`
+
+**Status: Mostly done (core compute path + helpers centralized).**
+
+- `App.jsx` now imports key analysis helpers directly from `src/core/analysisCore`.
+- Worker/fallback orchestration was extracted and uses `computeCoreResults` from `analysisCore`.
+
+Remaining follow-up:
+- Additional decomposition work is still possible in `App.jsx` for state/UI concerns not in `analysisCore`.
+
+## 2) Break up the ~3.5k-line `App.jsx`
+
+**Status: Partially done.**
+
+- Added `src/hooks/useCoreResultsEngine.js` and moved heavy compute orchestration out of `AppProvider`.
+- `App.jsx` is still large and should continue to be split into feature modules/hooks.
+
+## 3) Replace CDN Tailwind with build-time Tailwind pipeline
+
+**Status: Not done yet.**
+
+- `index.html` still uses `https://cdn.tailwindcss.com`.
+- Build-time migration is blocked in this environment because package installation from npm registry returned HTTP 403 policy errors.
+- Prep work completed: moved inline runtime Tailwind/theme bootstrap scripts into standalone files under `public/` to simplify eventual replacement with build-time assets.
+- Added `docs/tailwind-build-migration-plan.md` with blocker details and exact completion steps once dependency access is available.
+
+## 4) Add lint/format/type-oriented quality gates (local + CI)
+
+**Status: Done (with no-dependency gates).**
+
+- Added scripts: `lint`, `typecheck`, `perf:check`, `check`.
+- Added CI workflow that runs `npm run check` on push and pull request.
+
+## 5) Add worker/fallback observability + perf regression checks
+
+**Status: Done.**
+
+- Hook now tracks worker availability, fallback count, worker success/error counts, and last duration.
+- UI displays engine runtime stats.
+- Added performance regression tests and a perf check script.

--- a/docs/tailwind-build-migration-plan.md
+++ b/docs/tailwind-build-migration-plan.md
@@ -1,0 +1,43 @@
+# Tailwind build-time migration plan and blocker report
+
+## Current blocker
+
+Build-time Tailwind migration is blocked in this execution environment by network/security policy:
+
+- `npm install -D tailwindcss postcss autoprefixer` returns HTTP 403.
+- Direct binary download attempt from GitHub releases (`tailwindcss-linux-x64`) also returns HTTP 403 tunnel failure.
+
+Because of this, adding official Tailwind/PostCSS packages (or standalone CLI) was not possible from this environment.
+
+## What has already been done toward migration
+
+- Runtime dark-mode and Tailwind config scripts were moved out of inline HTML into:
+  - `public/theme-init.js`
+  - `public/tailwind-runtime-config.js`
+- `index.html` now references these files explicitly, reducing inline script coupling.
+
+## Final steps to complete migration (when package access is available)
+
+1. Install dependencies:
+   - `tailwindcss`
+   - `postcss`
+   - `autoprefixer`
+2. Create config files:
+   - `tailwind.config.js` with `darkMode: 'class'` and `content` globs for `index.html`, `src/**/*.{js,jsx}`.
+   - `postcss.config.js` using Tailwind + Autoprefixer.
+3. Add source CSS file, e.g. `src/styles/tailwind.css`:
+   - `@tailwind base;`
+   - `@tailwind components;`
+   - `@tailwind utilities;`
+4. Import the generated stylesheet from `src/main.jsx`.
+5. Remove runtime CDN script from `index.html`:
+   - Remove `https://cdn.tailwindcss.com`
+   - Remove `public/tailwind-runtime-config.js` reference.
+6. Add build check to CI:
+   - Optional: `npm run tailwind:build` or ensure Vite/PostCSS handles generation in `npm run build`.
+
+## Acceptance criteria
+
+- No `https://cdn.tailwindcss.com` reference remains.
+- Styling remains visually equivalent in light and dark mode.
+- `npm run check` continues to pass locally and in CI.

--- a/index.html
+++ b/index.html
@@ -4,34 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Aleph Code Calculator</title>
-  <script>
-    (() => {
-      let stored = null;
-      try {
-        stored = localStorage.getItem('alephTheme');
-      } catch (_err) {
-        stored = null;
-      }
-
-      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const isDark = stored ? stored === 'dark' : prefersDark;
-
-      document.documentElement.classList.toggle('dark', isDark);
-
-      const applyBodyTheme = () => {
-        if (document.body) document.body.classList.toggle('dark', isDark);
-      };
-
-      if (document.body) {
-        applyBodyTheme();
-      } else {
-        document.addEventListener('DOMContentLoaded', applyBodyTheme, { once: true });
-      }
-    })();
-  </script>
-  <script>
-    tailwind = { config: { darkMode: 'class' } };
-  </script>
+  <script src="/theme-init.js"></script>
+  <script src="/tailwind-runtime-config.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "preview": "vite preview",
     "test": "node --test",
     "test:watch": "node --test --watch",
-    "check": "npm run test && npm run build"
+    "lint": "node scripts/lint.mjs",
+    "typecheck": "node scripts/typecheck.mjs",
+    "perf:check": "node scripts/perf-check.mjs",
+    "check": "npm run lint && npm run typecheck && npm run test && npm run build && npm run perf:check"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/public/tailwind-runtime-config.js
+++ b/public/tailwind-runtime-config.js
@@ -1,0 +1,1 @@
+window.tailwind = { config: { darkMode: 'class' } };

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,23 @@
+(() => {
+  let stored = null;
+  try {
+    stored = localStorage.getItem('alephTheme');
+  } catch (_err) {
+    stored = null;
+  }
+
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isDark = stored ? stored === 'dark' : prefersDark;
+
+  document.documentElement.classList.toggle('dark', isDark);
+
+  const applyBodyTheme = () => {
+    if (document.body) document.body.classList.toggle('dark', isDark);
+  };
+
+  if (document.body) {
+    applyBodyTheme();
+  } else {
+    document.addEventListener('DOMContentLoaded', applyBodyTheme, { once: true });
+  }
+})();

--- a/scripts/complete-tailwind-migration.cmd
+++ b/scripts/complete-tailwind-migration.cmd
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+
+if not exist "%~dp0complete-tailwind-migration.mjs" (
+  echo Could not find complete-tailwind-migration.mjs next to this .cmd file.
+  exit /b 1
+)
+
+node "%~dp0complete-tailwind-migration.mjs"

--- a/scripts/complete-tailwind-migration.mjs
+++ b/scripts/complete-tailwind-migration.mjs
@@ -1,0 +1,50 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+console.log('[1/7] Installing Tailwind build dependencies...');
+run('npm install -D tailwindcss postcss autoprefixer');
+
+console.log('[2/7] Writing tailwind.config.js...');
+writeFileSync(
+  'tailwind.config.js',
+  `/** @type {import('tailwindcss').Config} */\nexport default {\n  darkMode: 'class',\n  content: [\n    './index.html',\n    './src/**/*.{js,jsx}',\n  ],\n  theme: {\n    extend: {},\n  },\n  plugins: [],\n};\n`,
+  'utf8'
+);
+
+console.log('[3/7] Writing postcss.config.js...');
+writeFileSync(
+  'postcss.config.js',
+  `export default {\n  plugins: {\n    tailwindcss: {},\n    autoprefixer: {},\n  },\n};\n`,
+  'utf8'
+);
+
+console.log('[4/7] Creating src/styles/tailwind.css...');
+if (!existsSync('src/styles')) mkdirSync('src/styles', { recursive: true });
+writeFileSync('src/styles/tailwind.css', '@tailwind base;\n@tailwind components;\n@tailwind utilities;\n', 'utf8');
+
+console.log('[5/7] Ensuring src/main.jsx imports Tailwind css...');
+const mainPath = 'src/main.jsx';
+let main = readFileSync(mainPath, 'utf8');
+if (!main.includes("./styles/tailwind.css")) {
+  main = main.replace("import App from './App';", "import App from './App';\nimport './styles/tailwind.css';");
+  writeFileSync(mainPath, main, 'utf8');
+}
+
+console.log('[6/7] Removing runtime CDN/config script refs from index.html...');
+const indexPath = 'index.html';
+let index = readFileSync(indexPath, 'utf8');
+index = index.replace('<script src="/tailwind-runtime-config.js"></script>\n', '');
+index = index.replace('<script src="/tailwind-runtime-config.js"></script>\r\n', '');
+index = index.replace('<script src="https://cdn.tailwindcss.com"></script>\n', '');
+index = index.replace('<script src="https://cdn.tailwindcss.com"></script>\r\n', '');
+writeFileSync(indexPath, index, 'utf8');
+
+console.log('[7/7] Running validation...');
+run('npm run check');
+
+console.log('Tailwind build-time migration steps completed.');
+console.log('Next: delete public/tailwind-runtime-config.js if no longer needed, then commit changes.');

--- a/scripts/complete-tailwind-migration.ps1
+++ b/scripts/complete-tailwind-migration.ps1
@@ -1,0 +1,14 @@
+# Run this from repo root on a machine that has npm registry access.
+# Example: powershell -ExecutionPolicy Bypass -File .\scripts\complete-tailwind-migration.ps1
+# Script version: 2026-04-10.3
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$nodeScript = Join-Path $scriptDir 'complete-tailwind-migration.mjs'
+
+if (-not (Test-Path $nodeScript)) {
+  throw "Could not find $nodeScript"
+}
+
+node $nodeScript

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOTS = ['src', 'tests', 'scripts'];
+const ALLOWED_EXT = new Set(['.js', '.jsx', '.mjs']);
+
+function collectFiles(dir, out) {
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      collectFiles(full, out);
+      continue;
+    }
+    const dot = entry.lastIndexOf('.');
+    const ext = dot === -1 ? '' : entry.slice(dot);
+    if (ALLOWED_EXT.has(ext)) out.push(full);
+  }
+}
+
+const files = [];
+for (const root of ROOTS) collectFiles(root, files);
+
+const violations = [];
+
+for (const file of files) {
+  const content = readFileSync(file, 'utf8');
+
+  if (content.includes('console.log(') && !file.startsWith('scripts/')) {
+    violations.push(`${file}: console.log is not allowed outside scripts/`);
+  }
+}
+
+if (violations.length) {
+  console.error('Lint violations found:');
+  for (const violation of violations) console.error(` - ${violation}`);
+  process.exit(1);
+}
+
+console.log(`lint passed for ${files.length} files`);

--- a/scripts/perf-check.mjs
+++ b/scripts/perf-check.mjs
@@ -1,0 +1,34 @@
+import { performance } from 'node:perf_hooks';
+import { computeCoreResults } from '../src/core/analysisCore.js';
+
+function makeHebrewText(word, wordsPerLine, lineCount) {
+  const line = Array.from({ length: wordsPerLine }, () => word).join(' ');
+  return Array.from({ length: lineCount }, () => line).join('\n');
+}
+
+const budgets = [
+  { label: 'medium', text: makeHebrewText('בראשית', 80, 40), mode: 'aleph-zero', maxMs: 2500 },
+  { label: 'large', text: makeHebrewText('אלהים', 120, 60), mode: 'aleph-one', maxMs: 5000 },
+];
+
+const failures = [];
+
+for (const run of budgets) {
+  const start = performance.now();
+  const results = computeCoreResults(run.text, run.mode);
+  const duration = performance.now() - start;
+  const rounded = Math.round(duration * 100) / 100;
+  console.log(`${run.label}: ${rounded}ms (${results.totalWordCount} words)`);
+
+  if (duration > run.maxMs) {
+    failures.push(`${run.label} exceeded ${run.maxMs}ms (actual ${rounded}ms)`);
+  }
+}
+
+if (failures.length) {
+  console.error('Performance regression check failed:');
+  for (const failure of failures) console.error(` - ${failure}`);
+  process.exit(1);
+}
+
+console.log('Performance regression check passed');

--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -1,0 +1,30 @@
+import { execSync } from 'node:child_process';
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOTS = ['src', 'tests', 'scripts'];
+const ALLOWED_EXT = new Set(['.js', '.mjs']);
+
+function collectFiles(dir, out) {
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      collectFiles(full, out);
+      continue;
+    }
+    const dot = entry.lastIndexOf('.');
+    const ext = dot === -1 ? '' : entry.slice(dot);
+    if (ALLOWED_EXT.has(ext)) out.push(full);
+  }
+}
+
+const files = [];
+for (const root of ROOTS) collectFiles(root, files);
+
+for (const file of files) {
+  execSync(`node --check ${JSON.stringify(file)}`, { stdio: 'inherit' });
+}
+
+console.log(`typecheck passed for ${files.length} files (syntax + module checks)`);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,24 @@
 import React, { useState, useMemo, useEffect, useRef, useCallback, useDeferredValue, useTransition, useLayoutEffect, useReducer, useContext, createContext, memo } from 'react';
 import VirtualizedList from './components/VirtualizedList';
+import EngineStatusBadge from './components/EngineStatusBadge';
 import { stripTrailingSpacesPerLine } from './utils/exportFormatting';
 import { matchesSearchQuery } from './core/searchQuery';
+import {
+    COLOR_PALETTE,
+    DEFAULT_DR_ORDER,
+    LAYER_COLORS,
+    PRIME_COLOR_HEX,
+    availableLayers,
+    buildLetterTable,
+    forceHebrewInput,
+    getLetterDetails,
+    getWordValues,
+    isValueVisible,
+    isWordVisible,
+    layersMatching,
+    strongestLayer,
+    topConnectionLayer,
+} from './core/analysisCore';
 import {
     EN_TO_HE_LETTER_MAP,
     EN_TO_HE_PUNCT_LETTER_MAP,
@@ -9,6 +26,8 @@ import {
     KEYBOARD_CODE_TO_HE_LETTER_MAP,
     normalizeSearchInput,
 } from './core/searchInput';
+import { useCoreResultsEngine } from './hooks/useCoreResultsEngine';
+import { useHebrewInputSanitizer } from './hooks/useHebrewInputSanitizer';
 
 // -----------------------------------------------------------------------------
 // 1. Context Definitions
@@ -62,20 +81,6 @@ function useAppStats() {
 // -----------------------------------------------------------------------------
 // 2. Constants & Styles
 // -----------------------------------------------------------------------------
-const BASE_LETTER_VALUES = {
-	'א': 1, 'ב': 2, 'ג': 3, 'ד': 4, 'ה': 5, 'ו': 6, 'ז': 7, 'ח': 8, 'ט': 9, 'י': 10,
-	'כ': 11, 'ל': 12, 'מ': 13, 'נ': 14, 'ס': 15, 'ע': 16, 'פ': 17, 'צ': 18, 'ק': 19,
-	'ר': 20, 'ש': 21, 'ת': 22,
-};
-const HEB_FINALS = { 'ך':'כ', 'ם':'מ', 'ן':'נ', 'ף':'פ', 'ץ':'צ' };
-const HYPHEN_RE = /[־–—\-]/g;
-const HEB_LETTER_RE = /[\u05D0-\u05EA\u05DA\u05DD\u05DF\u05E3\u05E5]/g;
-// Hebrew cantillation + nikkud marks (intentionally excludes maqaf U+05BE)
-const HEB_MARKS_RE = /[\u0591-\u05BD\u05BF-\u05C7]/g;
-// Includes Hebrew maqaf (U+05BE): "־"
-const INPUT_PUNCT_TO_SPACE_RE = /[^\u05D0-\u05EA\u05DA\u05DD\u05DF\u05E3\u05E5\n ]+/g;
-const INPUT_HEBREW_JOINERS_RE = /([\u05D0-\u05EA\u05DA\u05DD\u05DF\u05E3\u05E5])["'׳״‘’“”]+(?=[\u05D0-\u05EA\u05DA\u05DD\u05DF\u05E3\u05E5])/g;
-const INPUT_MULTI_SPACE_RE = / {2,}/g;
 const TEXT_SIZE_CLASSNAMES = Object.freeze({
     sm: 'text-base leading-6',
     md: 'text-lg leading-7',
@@ -86,54 +91,11 @@ const TEXT_SIZE_OPTIONS = Object.freeze([
     { value: 'md', label: 'בינוני' },
     { value: 'lg', label: 'גדול' },
 ]);
-// Combined Color Config: Darkened backgrounds for better visibility in light mode
-const LAYER_COLORS = {
-	U: { 
-        light: 'hsl(210, 70%, 85%)', // Darker pastel blue
-        dark: 'hsl(210, 30%, 25%)', 
-        dot: 'hsl(210, 100%, 40%)', 
-        strokeLight: '#0284c7',      
-        strokeDark: '#38bdf8'        
-    }, 
-	T: { 
-        light: 'hsl(140, 60%, 85%)', // Darker pastel green
-        dark: 'hsl(140, 30%, 22%)', 
-        dot: 'hsl(140, 100%, 30%)', 
-        strokeLight: '#059669',      
-        strokeDark: '#34d399'
-    }, 
-	H: { 
-        light: 'hsl(280, 65%, 88%)', // Darker pastel purple
-        dark: 'hsl(280, 25%, 28%)', 
-        dot: 'hsl(280, 100%, 45%)', 
-        strokeLight: '#9333ea',      
-        strokeDark: '#c084fc'
-    }, 
-};
-
-const LAYER_PRIORITY = ['H','T','U'];
-const COLOR_PALETTE = {
-    red: { light: 'text-red-600', dark: 'dark:text-red-400', name: 'אדום', bg: 'bg-red-500' },
-    yellow: { light: 'text-yellow-600', dark: 'dark:text-yellow-300', name: 'צהוב', bg: 'bg-yellow-400' },
-    emerald: { light: 'text-emerald-600', dark: 'dark:text-emerald-400', name: 'אזמרגד', bg: 'bg-emerald-500' },
-    sky: { light: 'text-sky-600', dark: 'dark:text-sky-400', name: 'שמיים', bg: 'bg-sky-500' },
-    pink: { light: 'text-pink-600', dark: 'dark:text-pink-400', name: 'ורוד', bg: 'bg-pink-500' },
-    purple: { light: 'text-purple-600', dark: 'dark:text-purple-400', name: 'סגול', bg: 'bg-purple-500' },
-    orange: { light: 'text-orange-600', dark: 'dark:text-orange-400', name: 'כתום', bg: 'bg-orange-500' },
-};
-const PRIME_COLOR_HEX = {
-    yellow: '#EAB308',
-    red: '#EF4444',
-    emerald: '#10B981',
-    sky: '#0EA5E9',
-    pink: '#EC4899',
-    purple: '#A855F7',
-    orange: '#F97316',
-};
-const DEFAULT_DR_ORDER = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+const HEB_MARKS_RE = /[\u0591-\u05BD\u05BF-\u05C7]/g;
+const INPUT_PUNCT_TO_SPACE_RE = /[^\u05D0-\u05EA\u05DA\u05DD\u05DF\u05E3\u05E5\n ]+/g;
+const INPUT_HEBREW_JOINERS_RE = /([\u05D0-\u05EA\u05DA\u05DD\u05DF\u05E3\u05E5])["'׳״‘’“”]+(?=[\u05D0-\u05EA\u05DA\u05DD\u05DF\u05E3\u05E5])/g;
+const INPUT_MULTI_SPACE_RE = / {2,}/g;
 const ALEPH_ZERO_DR_ORDER = [0, ...DEFAULT_DR_ORDER];
-const MAX_WORD_CACHE_SIZE = 50_000;
-const MAX_LETTER_DETAILS_CACHE_SIZE = 100_000;
 const LARGE_INPUT_SANITIZE_THRESHOLD = 80_000;
 const MIN_INPUT_ROWS = 4;
 const MAX_INPUT_ROWS = 18;
@@ -165,317 +127,8 @@ const GlobalStyles = () => (
 );
 
 // -----------------------------------------------------------------------------
-// 3. Logic Helpers & Calculators
+// 3. Logic Helpers
 // -----------------------------------------------------------------------------
-const MAX_SIEVE_SIZE = 20_000_000;
-let sieveArr = new Uint8Array(256);
-sieveArr[0] = 0; sieveArr[1] = 0;
-for(let i=2; i<256; i++) sieveArr[i]=1;
-for(let p=2; p*p<256; p++) { if(sieveArr[p]) { for(let i=p*p; i<256; i+=p) sieveArr[i]=0; } }
-
-function growSieveTo(limit) {
-    if (limit < sieveArr.length) return;
-    if (limit > MAX_SIEVE_SIZE) return; 
-    const target = Math.min(Math.max(limit, (sieveArr.length - 1) * 2), MAX_SIEVE_SIZE);
-    const oldLen = sieveArr.length;
-    const next = new Uint8Array(target + 1);
-    next.set(sieveArr);
-    next.fill(1, Math.max(2, oldLen));
-    const sqrtTarget = Math.sqrt(target);
-    for (let p = 2; p <= sqrtTarget; p++) {
-        if (next[p] !== 0) {
-            let start = p * p;
-            if (start < oldLen) start = Math.ceil(oldLen / p) * p;
-            for (let i = start; i <= target; i += p) next[i] = 0;
-        }
-    }
-    sieveArr = next;
-}
-
-const isPrimeExpand = (num) => {
-	if (num < 2) return false;
-    if (num > MAX_SIEVE_SIZE) {
-        if (num % 2 === 0) return false;
-        const sqrt = Math.sqrt(num);
-        for(let i = 3; i <= sqrt; i+=2) if (num % i === 0) return false;
-        return true;
-    }
-	if (num >= sieveArr.length) growSieveTo(num);
-	return sieveArr[num] === 1;
-};
-
-const getDigitalRoot = (n) => n === 0 ? 0 : 1 + ((n - 1) % 9);
-
-// Performance Optimization: Reduced allocation overhead by using direct checks and reusable logic
-const layersMatching = (hovered, current) => {
-	if (!hovered || !current) return [];
-	const matches = [];
-    
-    // We check which layer of 'current' (the target word) matches ANY layer of 'hovered' (the active word)
-    const hU = hovered.units, hT = hovered.tens, hH = hovered.hundreds;
-    const cU = current.units, cT = current.tens, cH = current.hundreds;
-
-    if (cU === hU || cU === hT || cU === hH) matches.push('U');
-    if (cT === hU || cT === hT || cT === hH) matches.push('T');
-    if (cH === hU || cH === hT || cH === hH) matches.push('H');
-
-	return matches;
-}
-
-const strongestLayer = (matchLayers) => LAYER_PRIORITY.find(L => matchLayers.includes(L)) || null;
-
-const LAYERS_U = Object.freeze(['U']);
-const LAYERS_UT = Object.freeze(['U','T']);
-const LAYERS_UTH = Object.freeze(['U','T','H']);
-const availableLayers = (w) => {
-	if (w.tens === w.units) return LAYERS_U;
-	if (w.hundreds === w.tens) return LAYERS_UT;
-	return LAYERS_UTH;
-};
-
-const topConnectionLayer = (source, target) => {
-	if (!source || !target) return null;
-	const hits = layersMatching(source, target);
-	if (!hits.length) return null;
-    
-    const sU = source.units, sT = source.tens, sH = source.hundreds;
-    const tU = target.units, tT = target.tens, tH = target.hundreds;
-    
-    const sourceLayers = [];
-    if (sH === tU || sH === tT || sH === tH) sourceLayers.push('H');
-    if (sT === tU || sT === tT || sT === tH) sourceLayers.push('T');
-    if (sU === tU || sU === tT || sU === tH) sourceLayers.push('U');
-
-	return strongestLayer(sourceLayers);
-};
-
-const buildLetterTable = (mode) => {
-	const table = new Map();
-	const letters = Object.keys(BASE_LETTER_VALUES);
-	for (const ch of letters) {
-		const m = BASE_LETTER_VALUES[ch]; 
-		const n = m - 1; 
-		let u, t, h;
-		if (mode === 'aleph-zero') {
-			u = n;
-			t = n <= 9 ? n : 10 * (n - 9);
-			if (n <= 10) h = n;
-			else if (n <= 19) h = 10 * (n - 9);
-			else h = 100 * (n - 18);
-		} else { 
-			u = m;
-			if (m <= 10) { t = m; h = m; } 
-			else {
-				t = (m - 9) * 10;
-				h = m <= 19 ? t : (m - 18) * 100;
-			}
-		}
-		table.set(ch, { u, t, h });
-	}
-	for (const [f, baseCh] of Object.entries(HEB_FINALS)) {
-		const r = table.get(baseCh);
-		if (r) table.set(f, { ...r });
-	}
-	return table;
-};
-
-const letterDetailsCache = new Map();
-const getLetterDetails = (word, letterTable) => {
-	const modeKey = letterTable.get('א')?.u === 0 ? '0' : '1';
-	const key = modeKey + '|' + word;
-	const hit = letterDetailsCache.get(key);
-	if (hit) return hit;
-	const details = [];
-	for (const ch of word) {
-		const rec = letterTable.get(ch);
-		if (rec) details.push({ char: ch, value: rec.u });
-	}
-	letterDetailsCache.set(key, details);
-	if (letterDetailsCache.size > MAX_LETTER_DETAILS_CACHE_SIZE) {
-		const oldestKey = letterDetailsCache.keys().next().value;
-		if (oldestKey) letterDetailsCache.delete(oldestKey);
-	}
-	return details;
-};
-
-function cleanHebrewToken(raw) {
-  const s = (raw.normalize ? raw.normalize('NFKD') : raw).replace(HEB_MARKS_RE, '');
-  const letters = s.match(HEB_LETTER_RE);
-  return letters ? letters.join('') : '';
-}
-
-function forceHebrewInput(raw) {
-    const withoutMarks = (raw.normalize ? raw.normalize('NFKD') : raw).replace(HEB_MARKS_RE, '');
-    const hasHebrewLetters = /[א-תךםןףץ]/.test(withoutMarks);
-    const keyMap = hasHebrewLetters
-        ? EN_TO_HE_LETTER_MAP
-        : { ...EN_TO_HE_LETTER_MAP, ...EN_TO_HE_PUNCT_LETTER_MAP };
-
-    const mapped = Array.from(withoutMarks).map((ch) => {
-        const lower = ch.toLowerCase();
-        const mappedChar = keyMap[lower];
-        return mappedChar || ch;
-    }).join('');
-    return mapped
-        .replace(INPUT_HEBREW_JOINERS_RE, '$1')
-        .replace(INPUT_PUNCT_TO_SPACE_RE, ' ')
-        .replace(INPUT_MULTI_SPACE_RE, ' ');
-}
-
-const makeWordComputer = (letterTable) => {
-	const cache = new Map();
-    const touchCacheEntry = (key, value) => {
-        cache.delete(key);
-        cache.set(key, value);
-    };
-
-    const pruneCacheIfNeeded = () => {
-        if (cache.size <= MAX_WORD_CACHE_SIZE) return;
-        const oldestKey = cache.keys().next().value;
-        if (oldestKey) cache.delete(oldestKey);
-    };
-
-    const computer = (rawWord) => {
-        const it = cleanHebrewToken(rawWord);
-        if (!it) return null;
-
-        const cached = cache.get(it);
-        if (cached !== undefined) {
-            touchCacheEntry(it, cached);
-            return cached;
-        }
-        
-		let u = 0, t = 0, h = 0;
-		let builtWord = "";
-        let maxU = -Infinity;
-        
-		for (const ch of it) {
-			const rec = letterTable.get(ch);
-			if (rec) {
-				builtWord += ch;
-				u += rec.u; t += rec.t; h += rec.h;
-            if (rec.u > maxU) maxU = rec.u;
-			}
-		}
-        
-		if (builtWord.length === 0) {
-            touchCacheEntry(it, null);
-            pruneCacheIfNeeded();
-            return null;
-        }
-        
-        const dr = getDigitalRoot(u);
-        const maxLayer = (maxU > 19) ? 'H' : (maxU > 10) ? 'T' : 'U';
-		const res = {
-			word: builtWord, 
-			units: u, tens: t, hundreds: h, dr,
-			isPrimeU: isPrimeExpand(u),
-			isPrimeT: t !== u && isPrimeExpand(t),
-			isPrimeH: h !== t && isPrimeExpand(h),
-			maxLayer
-		};
-		touchCacheEntry(it, res);
-        pruneCacheIfNeeded();
-		return res;
-	};
-    computer.clear = () => cache.clear();
-    return computer;
-};
-
-const memoizedComputers = {
-	'aleph-zero': makeWordComputer(buildLetterTable('aleph-zero')),
-	'aleph-one': makeWordComputer(buildLetterTable('aleph-one')),
-};
-
-function computeCoreResults(text, mode) {
-    letterDetailsCache.clear();
-	const lines = text.split('\n').filter(l => l.trim().length);
-	const computeWord = memoizedComputers[mode];
-	const allWordsMap = new Map();
-	const primeSummary = [];
-	const calculatedLines = [];
-	const wordCounts = new Map();
-	const drDistribution = new Uint32Array(10);
-	
-	let grandU = 0, grandT = 0, grandH = 0;
-	let totalWordCount = 0;
-
-	for (let li = 0; li < lines.length; li++) {
-		const lineWithSpacesForHyphens = lines[li].replace(HYPHEN_RE, ' ');
-		const words = lineWithSpacesForHyphens.split(/\s+/).filter(Boolean);
-		let lineU = 0, lineT = 0, lineH = 0;
-		const calcWords = [];
-		let lineMaxLayer = 'U';
-
-		for (const raw of words) {
-			const wd = computeWord(raw);
-			if (wd) {
-				totalWordCount++;
-				calcWords.push(wd);
-				lineU += wd.units; lineT += wd.tens; lineH += wd.hundreds;
-				if (wd.maxLayer === 'H') lineMaxLayer = 'H';
-				else if (wd.maxLayer === 'T' && lineMaxLayer !== 'H') lineMaxLayer = 'T';
-
-				if (!allWordsMap.has(wd.word)) allWordsMap.set(wd.word, wd);
-				drDistribution[wd.dr]++;
-				wordCounts.set(wd.word, (wordCounts.get(wd.word) || 0) + 1);
-			}
-		}
-		grandU += lineU; grandT += lineT; grandH += lineH;
-		growSieveTo(Math.max(lineU, lineT, lineH));
-		const isPrimeLineU = isPrimeExpand(lineU);
-		const isPrimeLineT = lineT !== lineU && isPrimeExpand(lineT);
-		const isPrimeLineH = lineH !== lineT && isPrimeExpand(lineH);
-		const linePrimes = {};
-		if (isPrimeLineU) { if (!linePrimes[lineU]) linePrimes[lineU] = []; linePrimes[lineU].push('אחדות'); }
-		if (isPrimeLineT) { if (!linePrimes[lineT]) linePrimes[lineT] = []; linePrimes[lineT].push('עשרות'); }
-		if (isPrimeLineH) { if (!linePrimes[lineH]) linePrimes[lineH] = []; linePrimes[lineH].push('מאות'); }
-		for (const [value, layers] of Object.entries(linePrimes)) {
-				primeSummary.push({ line: li + 1, value: parseInt(value), layers });
-		}
-		calculatedLines.push({
-			lineText: lines[li],
-			words: calcWords,
-			totals: { units: lineU, tens: lineT, hundreds: lineH },
-			totalsDR: getDigitalRoot(lineU),
-			isPrimeTotals: { U: isPrimeLineU, T: isPrimeLineT, H: isPrimeLineH },
-			lineMaxLayer
-		});
-	}
-	growSieveTo(Math.max(grandU, grandT, grandH));
-	const grandTotals = {
-		units: grandU, tens: grandT, hundreds: grandH,
-		dr: getDigitalRoot(grandU),
-		isPrime: { U: isPrimeExpand(grandU), T: isPrimeExpand(grandT), H: isPrimeExpand(grandH) },
-	};
-	return {
-		lines: calculatedLines, grandTotals, primeSummary,
-		allWords: Array.from(allWordsMap.values()),
-        wordDataMap: allWordsMap,
-		drDistribution, totalWordCount, wordCounts
-	};
-}
-
-const isValueVisible = (layer, isPrime, filters) => {
-    if (!filters[layer]) return false;
-    if (filters.Prime && !isPrime) return false;
-    return true;
-};
-
-const getWordValues = ({ hundreds, tens, units, isPrimeH, isPrimeT, isPrimeU }) => {
-    const out = [];
-    if (hundreds !== tens) out.push({ value: hundreds, isPrime: isPrimeH, layer: 'H' });
-    if (tens !== units)       out.push({ value: tens,      isPrime: isPrimeT, layer: 'T' });
-    out.push({ value: units, isPrime: isPrimeU, layer: 'U' });
-    return out;
-};
-
-const isWordVisible = (word, filters) => {
-    if (isValueVisible('U', word.isPrimeU, filters)) return true;
-    if (word.tens !== word.units && isValueVisible('T', word.isPrimeT, filters)) return true;
-    if (word.hundreds !== word.tens && isValueVisible('H', word.isPrimeH, filters)) return true;
-    return false;
-};
 
 // -----------------------------------------------------------------------------
 // 4. Initial State & Reducer
@@ -2151,50 +1804,15 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
     const commitTimerRef = useRef(null);
     const [isDragActive, setIsDragActive] = useState(false);
 
-    const sanitizeHebrewInput = useCallback((value = '') => {
-        const normalized = (value.normalize ? value.normalize('NFKD') : value)
-            .replace(HEB_MARKS_RE, '')
-            .replace(/\r\n?/g, '\n')
-            .replace(INPUT_HEBREW_JOINERS_RE, '$1')
-            .replace(INPUT_PUNCT_TO_SPACE_RE, ' ');
-        const hasHebrewLetters = /[א-תךםןףץ]/.test(normalized);
-        let output = '';
-
-        for (const ch of normalized) {
-            if (ch === ' ' || ch === '\n' || /^[א-ת]$/.test(ch)) {
-                output += ch;
-            } else {
-                const lower = ch.toLowerCase();
-                if (EN_TO_HE_LETTER_MAP[lower]) {
-                    output += EN_TO_HE_LETTER_MAP[lower];
-                } else if (!hasHebrewLetters && EN_TO_HE_PUNCT_LETTER_MAP[ch]) {
-                    output += EN_TO_HE_PUNCT_LETTER_MAP[ch];
-                } else if (!hasHebrewLetters && EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch]) {
-                    output += EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch];
-                } else {
-                    output += ' ';
-                }
-            }
-        }
-
-        return output
-            .replace(INPUT_MULTI_SPACE_RE, ' ')
-            .replace(/\n[ ]+/g, '\n');
-    }, []);
-
-    const sanitizePastedHebrewInput = useCallback((value = '') => (value.normalize ? value.normalize('NFKD') : value)
-        .replace(HEB_MARKS_RE, '')
-        .replace(/\r\n?/g, '\n')
-        .replace(INPUT_HEBREW_JOINERS_RE, '$1')
-        .replace(INPUT_PUNCT_TO_SPACE_RE, ' ')
-        .split('')
-        .filter((ch) => ch === ' ' || ch === '\n' || /^[א-ת]$/.test(ch))
-        .join('')
-        .replace(INPUT_MULTI_SPACE_RE, ' ')
-        .replace(/\n[ ]+/g, '\n')
-        .replace(/(^|[ \n])[א-ת](?=($|[ \n]))/g, '$1')
-        .replace(INPUT_MULTI_SPACE_RE, ' ')
-        .replace(/\n[ ]+/g, '\n'), []);
+    const { sanitizeHebrewInput, sanitizePastedHebrewInput } = useHebrewInputSanitizer({
+        HEB_MARKS_RE,
+        INPUT_HEBREW_JOINERS_RE,
+        INPUT_PUNCT_TO_SPACE_RE,
+        INPUT_MULTI_SPACE_RE,
+        EN_TO_HE_LETTER_MAP,
+        EN_TO_HE_PUNCT_LETTER_MAP,
+        EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP,
+    });
 
     const clearCommitTimer = useCallback(() => {
         if (commitTimerRef.current !== null) {
@@ -2488,7 +2106,7 @@ const App = () => {
         hotWordsList, isStatsCollapsed, showScrollTop, hotView, detailsView, hotSort,
         expandedRows, primeColor,
         stats, connectionValues, valueToWordsMap, filters,
-        hasExplicitThemeChoice, isPending 
+        hasExplicitThemeChoice, isPending, engineStats
     } = state;
 
     const clusterRefs = useRef({});
@@ -3024,6 +2642,7 @@ const App = () => {
                         />
                         <div className="mt-4 flex justify-center items-center gap-4 h-5">
                             {isPending && <span className="text-sm text-gray-500 dark:text-gray-400 noselect">מחשב...</span>}
+                            <EngineStatusBadge engineStats={engineStats} />
                         </div>
                     </div>
 
@@ -3370,76 +2989,15 @@ const App = () => {
 // -----------------------------------------------------------------------------
 function AppProvider({ children }) {
     const [state, dispatch] = useReducer(appReducer, initialState);
-    const [isPending, startTransition] = useTransition();
     const deferredText = useDeferredValue(state.text);
-    const versionRef = useRef(0);
-    const workerRef = useRef(null);
-
-    useEffect(() => {
-        try {
-            workerRef.current = new Worker(new URL('./workers/coreResults.worker.js', import.meta.url), { type: 'module' });
-        } catch {
-            workerRef.current = null;
-        }
-
-        return () => {
-            if (workerRef.current) {
-                workerRef.current.terminate();
-                workerRef.current = null;
-            }
-        };
+    const commitCoreResults = useCallback((results) => {
+        dispatch({ type: 'SET_CORE_RESULTS', payload: results });
     }, []);
-
-    useEffect(() => {
-        if (!deferredText) { dispatch({ type: 'SET_CORE_RESULTS', payload: null }); return; }
-
-        versionRef.current += 1;
-        const currentVersion = versionRef.current;
-        const worker = workerRef.current;
-        const delay = Math.min(800, Math.max(120, deferredText.length * 0.4));
-        const requestIdle = window.requestIdleCallback ?? ((fn) => setTimeout(fn, 1));
-        const cancelIdle = window.cancelIdleCallback ?? clearTimeout;
-        let workerListener = null;
-        let idleId = null;
-
-        const timerId = setTimeout(() => {
-            if (worker) {
-                workerListener = (event) => {
-                    const { requestId, results, error } = event.data || {};
-                    if (requestId !== currentVersion) return;
-                    worker.removeEventListener('message', workerListener);
-                    workerListener = null;
-                    if (error) return;
-                    startTransition(() => {
-                        if (versionRef.current === currentVersion) {
-                            dispatch({ type: 'SET_CORE_RESULTS', payload: results });
-                        }
-                    });
-                };
-
-                worker.addEventListener('message', workerListener);
-                worker.postMessage({ requestId: currentVersion, text: deferredText, mode: state.mode });
-                return;
-            }
-
-            idleId = requestIdle(() => {
-                startTransition(() => {
-                    const results = computeCoreResults(deferredText, state.mode);
-                    if (versionRef.current === currentVersion) {
-                        dispatch({ type: 'SET_CORE_RESULTS', payload: results });
-                    }
-                });
-            });
-        }, delay);
-
-        return () => {
-            clearTimeout(timerId);
-            if (idleId) cancelIdle(idleId);
-            if (worker && workerListener) {
-                worker.removeEventListener('message', workerListener);
-            }
-        };
-    }, [deferredText, state.mode]);
+    const { isPending, engineStats } = useCoreResultsEngine({
+        deferredText,
+        mode: state.mode,
+        onResults: commitCoreResults,
+    });
 
     const stats = useMemo(() => {
         if (!state.coreResults) return null;
@@ -3503,13 +3061,14 @@ function AppProvider({ children }) {
          return visibleConnections;
     }, [state.coreResults, state.filters]);
 
-    const contextValue = useMemo(() => ({ 
-        ...state, 
-        stats, 
-        valueToWordsMap, 
+    const contextValue = useMemo(() => ({
+        ...state,
+        stats,
+        valueToWordsMap,
         connectionValues,
-        isPending
-    }), [state, stats, valueToWordsMap, connectionValues, isPending]);
+        isPending,
+        engineStats,
+    }), [state, stats, valueToWordsMap, connectionValues, isPending, engineStats]);
 
     return (
         <AppContext.Provider value={contextValue}>

--- a/src/components/EngineStatusBadge.jsx
+++ b/src/components/EngineStatusBadge.jsx
@@ -1,0 +1,15 @@
+import React, { memo } from 'react';
+
+const EngineStatusBadge = memo(({ engineStats }) => {
+  if (!engineStats) return null;
+
+  return (
+    <span className="text-xs text-gray-400 dark:text-gray-500 noselect">
+      מנוע: {engineStats.workerAvailable ? 'Worker' : 'Main'} ·
+      זמן אחרון: {engineStats.lastDurationMs}ms ·
+      fallback: {engineStats.fallbackCount}
+    </span>
+  );
+});
+
+export default EngineStatusBadge;

--- a/src/hooks/useCoreResultsEngine.js
+++ b/src/hooks/useCoreResultsEngine.js
@@ -1,0 +1,121 @@
+import { useEffect, useRef, useState, useTransition } from 'react';
+import { computeCoreResults } from '../core/analysisCore';
+
+const requestIdle = (cb) => {
+  const scheduler = globalThis.requestIdleCallback;
+  return scheduler ? scheduler(cb) : setTimeout(cb, 1);
+};
+
+const cancelIdle = (id) => {
+  const scheduler = globalThis.cancelIdleCallback;
+  if (scheduler) {
+    scheduler(id);
+    return;
+  }
+  clearTimeout(id);
+};
+
+export function useCoreResultsEngine({ deferredText, mode, onResults }) {
+  const [isPending, startTransition] = useTransition();
+  const [engineStats, setEngineStats] = useState({
+    workerAvailable: false,
+    fallbackCount: 0,
+    workerSuccessCount: 0,
+    workerErrorCount: 0,
+    lastDurationMs: 0,
+  });
+
+  const versionRef = useRef(0);
+  const workerRef = useRef(null);
+
+  useEffect(() => {
+    try {
+      workerRef.current = new Worker(new URL('../workers/coreResults.worker.js', import.meta.url), { type: 'module' });
+      setEngineStats((prev) => ({ ...prev, workerAvailable: true }));
+    } catch {
+      workerRef.current = null;
+      setEngineStats((prev) => ({ ...prev, workerAvailable: false }));
+    }
+
+    return () => {
+      if (workerRef.current) {
+        workerRef.current.terminate();
+        workerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!deferredText) {
+      onResults(null);
+      return;
+    }
+
+    versionRef.current += 1;
+    const currentVersion = versionRef.current;
+    const worker = workerRef.current;
+    const delay = Math.min(800, Math.max(120, deferredText.length * 0.4));
+    let workerListener = null;
+    let idleId = null;
+
+    const timerId = setTimeout(() => {
+      const startedAt = performance.now();
+      if (worker) {
+        workerListener = (event) => {
+          const { requestId, results, error } = event.data || {};
+          if (requestId !== currentVersion) return;
+          worker.removeEventListener('message', workerListener);
+          workerListener = null;
+
+          const endedAt = performance.now();
+          setEngineStats((prev) => ({
+            ...prev,
+            lastDurationMs: Math.round((endedAt - startedAt) * 100) / 100,
+            workerErrorCount: error ? prev.workerErrorCount + 1 : prev.workerErrorCount,
+            workerSuccessCount: error ? prev.workerSuccessCount : prev.workerSuccessCount + 1,
+          }));
+
+          if (error) {
+            return;
+          }
+
+          startTransition(() => {
+            if (versionRef.current === currentVersion) {
+              onResults(results);
+            }
+          });
+        };
+
+        worker.addEventListener('message', workerListener);
+        worker.postMessage({ requestId: currentVersion, text: deferredText, mode });
+        return;
+      }
+
+      idleId = requestIdle(() => {
+        startTransition(() => {
+          const results = computeCoreResults(deferredText, mode);
+          const endedAt = performance.now();
+          setEngineStats((prev) => ({
+            ...prev,
+            fallbackCount: prev.fallbackCount + 1,
+            lastDurationMs: Math.round((endedAt - startedAt) * 100) / 100,
+          }));
+
+          if (versionRef.current === currentVersion) {
+            onResults(results);
+          }
+        });
+      });
+    }, delay);
+
+    return () => {
+      clearTimeout(timerId);
+      if (idleId) cancelIdle(idleId);
+      if (worker && workerListener) {
+        worker.removeEventListener('message', workerListener);
+      }
+    };
+  }, [deferredText, mode, onResults, startTransition]);
+
+  return { isPending, engineStats };
+}

--- a/src/hooks/useHebrewInputSanitizer.js
+++ b/src/hooks/useHebrewInputSanitizer.js
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+
+export function useHebrewInputSanitizer({
+  HEB_MARKS_RE,
+  INPUT_HEBREW_JOINERS_RE,
+  INPUT_PUNCT_TO_SPACE_RE,
+  INPUT_MULTI_SPACE_RE,
+  EN_TO_HE_LETTER_MAP,
+  EN_TO_HE_PUNCT_LETTER_MAP,
+  EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP,
+}) {
+  const sanitizeHebrewInput = useCallback((value = '') => {
+    const normalized = (value.normalize ? value.normalize('NFKD') : value)
+      .replace(HEB_MARKS_RE, '')
+      .replace(/\r\n?/g, '\n')
+      .replace(INPUT_HEBREW_JOINERS_RE, '$1')
+      .replace(INPUT_PUNCT_TO_SPACE_RE, ' ');
+    const hasHebrewLetters = /[א-תךםןףץ]/.test(normalized);
+    let output = '';
+
+    for (const ch of normalized) {
+      if (ch === ' ' || ch === '\n' || /^[א-ת]$/.test(ch)) {
+        output += ch;
+      } else {
+        const lower = ch.toLowerCase();
+        if (EN_TO_HE_LETTER_MAP[lower]) {
+          output += EN_TO_HE_LETTER_MAP[lower];
+        } else if (!hasHebrewLetters && EN_TO_HE_PUNCT_LETTER_MAP[ch]) {
+          output += EN_TO_HE_PUNCT_LETTER_MAP[ch];
+        } else if (!hasHebrewLetters && EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch]) {
+          output += EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch];
+        } else {
+          output += ' ';
+        }
+      }
+    }
+
+    return output
+      .replace(INPUT_MULTI_SPACE_RE, ' ')
+      .replace(/\n[ ]+/g, '\n');
+  }, [
+    EN_TO_HE_LETTER_MAP,
+    EN_TO_HE_PUNCT_LETTER_MAP,
+    EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP,
+    HEB_MARKS_RE,
+    INPUT_HEBREW_JOINERS_RE,
+    INPUT_PUNCT_TO_SPACE_RE,
+    INPUT_MULTI_SPACE_RE,
+  ]);
+
+  const sanitizePastedHebrewInput = useCallback((value = '') => (value.normalize ? value.normalize('NFKD') : value)
+    .replace(HEB_MARKS_RE, '')
+    .replace(/\r\n?/g, '\n')
+    .replace(INPUT_HEBREW_JOINERS_RE, '$1')
+    .replace(INPUT_PUNCT_TO_SPACE_RE, ' ')
+    .split('')
+    .filter((ch) => ch === ' ' || ch === '\n' || /^[א-ת]$/.test(ch))
+    .join('')
+    .replace(INPUT_MULTI_SPACE_RE, ' ')
+    .replace(/\n[ ]+/g, '\n')
+    .replace(/(^|[ \n])[א-ת](?=($|[ \n]))/g, '$1')
+    .replace(INPUT_MULTI_SPACE_RE, ' ')
+    .replace(/\n[ ]+/g, '\n'), [
+    HEB_MARKS_RE,
+    INPUT_HEBREW_JOINERS_RE,
+    INPUT_PUNCT_TO_SPACE_RE,
+    INPUT_MULTI_SPACE_RE,
+  ]);
+
+  return { sanitizeHebrewInput, sanitizePastedHebrewInput };
+}

--- a/tests/performance.test.js
+++ b/tests/performance.test.js
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeCoreResults } from '../src/core/analysisCore.js';
+
+function makeHebrewText(word, wordsPerLine, lineCount) {
+  const line = Array.from({ length: wordsPerLine }, () => word).join(' ');
+  return Array.from({ length: lineCount }, () => line).join('\n');
+}
+
+test('computeCoreResults stays within regression budget on medium corpus', () => {
+  const sample = makeHebrewText('בראשית', 80, 40); // 3,200 words
+  const start = performance.now();
+  const results = computeCoreResults(sample, 'aleph-zero');
+  const duration = performance.now() - start;
+
+  assert.equal(results.totalWordCount, 3200);
+  assert.ok(duration < 2500, `Expected compute under 2500ms, got ${duration.toFixed(2)}ms`);
+});
+
+test('computeCoreResults scales for larger corpus without timing out', () => {
+  const sample = makeHebrewText('אלהים', 120, 60); // 7,200 words
+  const start = performance.now();
+  const results = computeCoreResults(sample, 'aleph-one');
+  const duration = performance.now() - start;
+
+  assert.equal(results.totalWordCount, 7200);
+  assert.ok(duration < 5000, `Expected compute under 5000ms, got ${duration.toFixed(2)}ms`);
+});


### PR DESCRIPTION
### Motivation
- Add automated quality gates and a CI workflow to ensure linting, type checks, tests, build and perf checks run on push/PR. 
- Prepare and document a safe migration from CDN Tailwind to a build-time Tailwind pipeline while the environment is blocked from reaching npm/GitHub binaries. 
- Reduce duplication by centralizing compute logic and expose engine status/observability in the UI.

### Description
- Added GitHub Actions workflow `/.github/workflows/ci.yml` to run `npm run check` on push and pull requests. 
- Introduced local quality scripts and checks in `package.json`: `lint`, `typecheck`, `perf:check`, and updated `check` to run them plus `test` and `build`. 
- Added small static tools: `scripts/lint.mjs`, `scripts/typecheck.mjs`, and `scripts/perf-check.mjs` for lightweight linting, syntax checking, and performance regression checks. 
- Created Tailwind migration helpers and docs: `scripts/complete-tailwind-migration.*`, `docs/tailwind-build-migration-plan.md`, and user-facing docs `docs/dependency-access-for-agent.md`, `docs/pull-troubleshooting.md`, `docs/repo-investigation-2026-04-09.md`, and `docs/repo-investigation-status-2026-04-09.md`. 
- Refactored app compute orchestration: added `src/hooks/useCoreResultsEngine.js` and `src/hooks/useHebrewInputSanitizer.js`, added `src/components/EngineStatusBadge.jsx`, and updated `src/App.jsx` to use these hooks and import helpers from `src/core/analysisCore.js` (removing duplicated compute logic). 
- Moved runtime theme/Tailwind config out of `index.html` into `public/theme-init.js` and `public/tailwind-runtime-config.js`, and added `scripts/complete-tailwind-migration.mjs` to perform the build-time migration when package access is available. 
- Added performance tests in `tests/performance.test.js` that exercise `computeCoreResults` on medium and large sample corpora.

### Testing
- Added a CI job that runs `npm run check` (which executes `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`, and `npm run perf:check`) on push and pull requests. 
- Ran the unit and performance tests with `node --test` including the new `tests/performance.test.js`, and the performance assertions passed locally. 
- Executed `scripts/lint.mjs`, `scripts/typecheck.mjs`, and `scripts/perf-check.mjs` locally and they completed without failures under the environment used for development.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8167dc6a88323a4dd2ee27807529a)