### PR TITLE
Hide engine debug status badge from main UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo, useEffect, useRef, useCallback, useDeferredValue, useTransition, useLayoutEffect, useReducer, useContext, createContext, memo } from 'react';
 import VirtualizedList from './components/VirtualizedList';
-import EngineStatusBadge from './components/EngineStatusBadge';
 import { stripTrailingSpacesPerLine } from './utils/exportFormatting';
 import { matchesSearchQuery } from './core/searchQuery';
 import {
@@ -2109,7 +2108,7 @@ const App = () => {
         hotWordsList, isStatsCollapsed, showScrollTop, hotView, detailsView, hotSort,
         expandedRows, primeColor,
         stats, connectionValues, valueToWordsMap, filters,
-        hasExplicitThemeChoice, isPending, engineStats
+        hasExplicitThemeChoice, isPending
     } = state;
 
     const clusterRefs = useRef({});
@@ -2645,7 +2644,6 @@ const App = () => {
                         />
                         <div className="mt-4 flex justify-center items-center gap-4 h-5">
                             {isPending && <span className="text-sm text-gray-500 dark:text-gray-400 noselect">מחשב...</span>}
-                            <EngineStatusBadge engineStats={engineStats} />
                         </div>
                     </div>
 


### PR DESCRIPTION
### Motivation
- Remove an on-screen debug/status indicator that exposes internal engine timing and fallback details from the main input area to avoid showing internal diagnostics to end users.

### Description
- Stop rendering the `EngineStatusBadge` in the main input area by removing its JSX usage in `src/App.jsx`.
- Remove the now-unused `engineStats` value from the `App` state destructuring in `src/App.jsx`.
- Leave the `EngineStatusBadge` component file intact for possible future use while keeping the UI free of the debug badge.

### Testing
- Ran `npm run lint` and the linter passed for the repository.
- Ran `npm run build` (Vite production build) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fe5aef148323adaba36a287e5912)