### PR TITLE
Remove EngineStatusBadge, expose prime-line count in UI, and clean up unused state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo, useEffect, useRef, useCallback, useDeferredValue, useTransition, useLayoutEffect, useReducer, useContext, createContext, memo } from 'react';
 import VirtualizedList from './components/VirtualizedList';
-import EngineStatusBadge from './components/EngineStatusBadge';
 import { stripTrailingSpacesPerLine } from './utils/exportFormatting';
 import { matchesSearchQuery } from './core/searchQuery';
 import {
@@ -2109,7 +2108,7 @@ const App = () => {
         hotWordsList, isStatsCollapsed, showScrollTop, hotView, detailsView, hotSort,
         expandedRows, primeColor,
         stats, connectionValues, valueToWordsMap, filters,
-        hasExplicitThemeChoice, isPending, engineStats
+        hasExplicitThemeChoice, isPending
     } = state;
 
     const clusterRefs = useRef({});
@@ -2645,7 +2644,6 @@ const App = () => {
                         />
                         <div className="mt-4 flex justify-center items-center gap-4 h-5">
                             {isPending && <span className="text-sm text-gray-500 dark:text-gray-400 noselect">מחשב...</span>}
-                            <EngineStatusBadge engineStats={engineStats} />
                         </div>
                     </div>
 
@@ -2726,12 +2724,11 @@ const App = () => {
                                     {coreResults.primeSummary.length > 0 && (
                                         <div className={`p-4 sm:p-6 rounded-xl border mb-8 ${isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-slate-50/95 border-slate-300 shadow-[0_18px_45px_-30px_rgba(15,23,42,0.7)]'}`}>
                                             <button onClick={() => dispatch({ type: 'TOGGLE_PRIMES_COLLAPSED' })} className="w-full flex justify-between items-center text-2xl font-bold text-gray-800 dark:text-gray-200 noselect">
-                                                <span className="text-center flex-grow">סיכום ראשוניים מסכומי השורות</span>
+                                                <span className="text-center flex-grow">{stats.primeLineTotals} שורות ראשוניות</span>
                                                 <Icon name="chevron-down" className={`w-6 h-6 transition-transform duration-300 ${isPrimesCollapsed ? '' : 'rotate-180'}`} />
                                             </button>
                                             {!isPrimesCollapsed && (
                                                 <div className="mt-4">
-                                                    <p className={`text-center mb-4 ${isDarkMode ? 'text-gray-400' : 'text-slate-600'}`}>בסך הכל נמצאו <span className="font-bold text-emerald-600">{stats.primeLineTotals}</span> שורות עם ערכים ראשוניים.</p>
                                                     <div className="overflow-x-auto max-w-lg mx-auto">
                                                         <table className="min-w-full"><thead className={isDarkMode ? 'bg-gray-700' : 'bg-gradient-to-l from-slate-100 to-emerald-100'}>
                                                             <tr><th className="px-4 py-3 text-center">שורה</th><th className="px-4 py-3 text-center">ערך ראשוני</th><th className="px-4 py-3 text-center">שכבה</th></tr>


### PR DESCRIPTION
### Motivation
- Remove an unused engine status UI element and corresponding state to simplify the top-bar UI and state shape.
- Surface the count of prime-valued lines directly in the primes summary header to make the information more visible.
- Clean up redundant text and ensure the value-table click-outside behavior remains explicit.

### Description
- Removed the `EngineStatusBadge` import and its JSX usage from the main app header.
- Dropped the now-unused `engineStats` field from the app state destructuring to avoid keeping obsolete state references.
- Replaced the static primes summary title with a dynamic header using `stats.primeLineTotals` and removed a redundant paragraph that duplicated that count.
- Kept the explicit close behavior for the value table when clicking outside by dispatching `CLOSE_VALUE_TABLE` in the click handler.

### Testing
- Ran the frontend unit test suite with `npm test`, and all tests passed.
- Performed a production build with `npm run build`, which completed successfully.
- Ran `npm run lint` to ensure code style and the linter returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fe5aef148323adaba36a287e5912)