### PR TITLE
Make textarea bottom perimeter draggable with full-width resize handle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1862,7 +1862,11 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
     const textareaRef = useRef(null);
     const draftRef = useRef(text);
     const commitTimerRef = useRef(null);
+    const dragStateRef = useRef(null);
+    const minTextareaHeightRef = useRef(0);
+    const maxTextareaHeightRef = useRef(Number.POSITIVE_INFINITY);
     const [isDragActive, setIsDragActive] = useState(false);
+    const [manualHeight, setManualHeight] = useState(null);
 
     const { sanitizeHebrewInput, sanitizePastedHebrewInput } = useHebrewInputSanitizer({
         HEB_MARKS_RE,
@@ -1895,6 +1899,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         const minHeight = (lineHeight * MIN_INPUT_ROWS) + chromeHeight;
         const maxHeight = (lineHeight * MAX_INPUT_ROWS) + chromeHeight;
 
+        minTextareaHeightRef.current = minHeight;
+        maxTextareaHeightRef.current = maxHeight;
         textarea.style.minHeight = `${minHeight}px`;
         textarea.style.maxHeight = `${maxHeight}px`;
         textarea.style.overflowY = 'auto';
@@ -2129,27 +2135,73 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         insertTextAtCursor(droppedText);
     }, [insertTextAtCursor]);
 
+    const handleResizeDragMove = useCallback((event) => {
+        const dragState = dragStateRef.current;
+        if (!dragState) return;
+
+        const heightDelta = event.clientY - dragState.startClientY;
+        const nextHeight = dragState.startHeight + heightDelta;
+        const boundedHeight = Math.min(
+            maxTextareaHeightRef.current,
+            Math.max(minTextareaHeightRef.current, nextHeight),
+        );
+        setManualHeight(boundedHeight);
+    }, []);
+
+    const stopResizeDrag = useCallback(() => {
+        if (!dragStateRef.current) return;
+        dragStateRef.current = null;
+        window.removeEventListener('mousemove', handleResizeDragMove);
+        window.removeEventListener('mouseup', stopResizeDrag);
+    }, [handleResizeDragMove]);
+
+    const beginResizeDrag = useCallback((event) => {
+        event.preventDefault();
+
+        const textarea = textareaRef.current;
+        if (!textarea) return;
+
+        const rect = textarea.getBoundingClientRect();
+        dragStateRef.current = {
+            startClientY: event.clientY,
+            startHeight: rect.height,
+        };
+
+        window.addEventListener('mousemove', handleResizeDragMove);
+        window.addEventListener('mouseup', stopResizeDrag);
+    }, [handleResizeDragMove, stopResizeDrag]);
+
+    useEffect(() => () => stopResizeDrag(), [stopResizeDrag]);
+
     return (
-        <textarea
-            ref={textareaRef}
-            dir="rtl"
-            id="text-input"
-            className={`w-full resize-y p-4 border rounded-lg focus:ring-2 focus:border-blue-500 transition duration-150 text-right ${TEXT_SIZE_CLASSNAMES[textSize] || TEXT_SIZE_CLASSNAMES.md} ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400' : 'bg-gray-50 border-gray-300'} ${isDragActive ? 'ring-2 ring-blue-400 border-blue-400' : ''}`}
-            rows={MIN_INPUT_ROWS}
-            defaultValue={text}
-            onChange={handleChange}
-            onBlur={commitChanges}
-            onKeyDown={handleKeyDown}
-            onPaste={handlePaste}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-            spellCheck={false}
-            autoCorrect="off"
-            autoCapitalize="off"
-            autoComplete="off"
-            placeholder="הזן טקסט לניתוח"
-        />
+        <div className="relative">
+            <textarea
+                ref={textareaRef}
+                dir="rtl"
+                id="text-input"
+                className={`w-full resize-none p-4 border rounded-lg focus:ring-2 focus:border-blue-500 transition duration-150 text-right ${TEXT_SIZE_CLASSNAMES[textSize] || TEXT_SIZE_CLASSNAMES.md} ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400' : 'bg-gray-50 border-gray-300'} ${isDragActive ? 'ring-2 ring-blue-400 border-blue-400' : ''}`}
+                style={manualHeight !== null ? { height: `${manualHeight}px` } : undefined}
+                rows={MIN_INPUT_ROWS}
+                defaultValue={text}
+                onChange={handleChange}
+                onBlur={commitChanges}
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                spellCheck={false}
+                autoCorrect="off"
+                autoCapitalize="off"
+                autoComplete="off"
+                placeholder="הזן טקסט לניתוח"
+            />
+            <div
+                role="presentation"
+                className="absolute bottom-0 left-0 right-0 h-4 cursor-ns-resize"
+                onMouseDown={beginResizeDrag}
+            />
+        </div>
     );
 });
 


### PR DESCRIPTION
### Motivation
- Improve the textarea resizing UX by replacing the tiny native corner handle with a full-width bottom drag strip so the input field is easier to resize with the mouse.
- Preserve existing automatic row-based sizing and bounds while allowing manual drag resizing.

### Description
- Wrap the main input `textarea` in a `relative` container and add a full-width bottom handle element with `cursor-ns-resize` that begins the resize drag (`beginResizeDrag`).
- Add drag state refs and state (`dragStateRef`, `minTextareaHeightRef`, `maxTextareaHeightRef`, `manualHeight`) and handlers (`handleResizeDragMove`, `stopResizeDrag`) to calculate and clamp the manual height between the existing min/max row bounds computed by `applyTextareaRowBounds`.
- Disable the native corner resize by switching the textarea to `resize-none` and apply the computed `manualHeight` via `style` when dragging, while keeping all existing input behaviors (sanitization, paste handling, file drop, keyboard mapping).

### Testing
- Ran `npm test -- --runInBand` which failed because the Node test runner does not accept the `--runInBand` option. (expected environment mismatch)
- Ran `npm test` and all automated tests passed (`31` tests, `0` failures).
- Ran `npm run lint` and linting passed for the project files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c6d195e4832383d321b3298aa95f)