### PR TITLE
Fix connection grouping to ignore self-shared values

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import {
 } from './core/searchInput';
 import { useCoreResultsEngine } from './hooks/useCoreResultsEngine';
 import { useHebrewInputSanitizer } from './hooks/useHebrewInputSanitizer';
+import { getConnectionValues } from './core/wordConnections';
 
 // -----------------------------------------------------------------------------
 // 1. Context Definitions
@@ -3144,39 +3145,7 @@ function AppProvider({ children }) {
 
     const connectionValues = useMemo(() => {
          if (!state.coreResults) return new Set();
-         const visibleConnections = new Set();
-         const valueCounts = new Map();
-
-         state.coreResults.allWords.forEach((word) => {
-             const visibleValues = [];
-
-             if (word.hundreds !== word.tens && isValueVisible('H', word.isPrimeH, state.filters)) {
-                 visibleValues.push(word.hundreds);
-             }
-             if (word.tens !== word.units && isValueVisible('T', word.isPrimeT, state.filters)) {
-                 visibleValues.push(word.tens);
-             }
-             if (isValueVisible('U', word.isPrimeU, state.filters)) {
-                 visibleValues.push(word.units);
-             }
-
-             if (visibleValues.length === 0) return;
-
-             if (visibleValues.length > 1) {
-                 visibleValues.sort((a, b) => a - b);
-             }
-
-             let prevValue;
-             visibleValues.forEach((value) => {
-                 if (value === prevValue) return;
-                 const nextCount = (valueCounts.get(value) || 0) + 1;
-                 valueCounts.set(value, nextCount);
-                 if (nextCount > 1) visibleConnections.add(value);
-                 prevValue = value;
-             });
-         });
-
-         return visibleConnections;
+         return getConnectionValues(state.coreResults.allWords, state.filters);
     }, [state.coreResults, state.filters]);
 
     const contextValue = useMemo(() => ({

--- a/src/core/wordConnections.js
+++ b/src/core/wordConnections.js
@@ -71,3 +71,22 @@ export function computeConnectedWordsSet(activeWord, visibleValuesByWord, wordsB
 
     return connected;
 }
+
+export function getConnectionValues(words, filters) {
+    const valueToWordSet = new Map();
+
+    words.forEach((wordData) => {
+        const visibleValues = new Set(getVisibleValuesForWord(wordData, filters));
+        visibleValues.forEach((value) => {
+            if (!valueToWordSet.has(value)) valueToWordSet.set(value, new Set());
+            valueToWordSet.get(value).add(wordData.word);
+        });
+    });
+
+    const connectedValues = new Set();
+    valueToWordSet.forEach((wordSet, value) => {
+        if (wordSet.size > 1) connectedValues.add(value);
+    });
+
+    return connectedValues;
+}

--- a/src/state/appStore.jsx
+++ b/src/state/appStore.jsx
@@ -8,7 +8,8 @@ import React, {
     useRef,
     useTransition,
 } from 'react';
-import { computeCoreResults, getWordValues, isValueVisible } from '../core/analysisCore';
+import { computeCoreResults } from '../core/analysisCore';
+import { getConnectionValues } from '../core/wordConnections';
 import { appReducer, initialState } from './appReducer';
 
 const AppCoreContext = createContext(null);
@@ -127,25 +128,7 @@ const AppProvider = ({ children }) => {
 
     const connectionValues = useMemo(() => {
         if (!state.coreResults) return new Set();
-        const visibleConnections = new Set();
-        const valCounts = new Map();
-
-        state.coreResults.allWords.forEach((wordData) => {
-            const seenInWord = new Set();
-            const values = getWordValues(wordData);
-            values.forEach((valueData) => {
-                if (!isValueVisible(valueData.layer, valueData.isPrime, state.filters)) return;
-                if (seenInWord.has(valueData.value)) return;
-                seenInWord.add(valueData.value);
-                valCounts.set(valueData.value, (valCounts.get(valueData.value) || 0) + 1);
-            });
-        });
-
-        for (const [value, count] of valCounts.entries()) {
-            if (count > 1) visibleConnections.add(value);
-        }
-
-        return visibleConnections;
+        return getConnectionValues(state.coreResults.allWords, state.filters);
     }, [state.coreResults, state.filters]);
 
     const coreValue = useMemo(

--- a/tests/wordConnections.test.js
+++ b/tests/wordConnections.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { getVisibleValuesForWord, buildWordConnectionIndex, computeConnectedWordsSet } from '../src/core/wordConnections.js';
+import { getVisibleValuesForWord, buildWordConnectionIndex, computeConnectedWordsSet, getConnectionValues } from '../src/core/wordConnections.js';
 
 const wordA = {
     word: 'אב',
@@ -57,4 +57,33 @@ test('computeConnectedWordsSet returns words sharing visible values with active 
     assert.equal(connected.has('גד'), true);
     assert.equal(connected.has('הו'), false);
     assert.equal(connected.has('אב'), false);
+});
+
+test('getConnectionValues counts sharing across distinct words only', () => {
+    const repeatedWord = {
+        word: 'עח',
+        units: 78,
+        tens: 51,
+        hundreds: 78,
+        isPrimeU: false,
+        isPrimeT: false,
+        isPrimeH: false,
+    };
+    const uniqueWord = {
+        word: 'יחיד',
+        units: 12,
+        tens: 30,
+        hundreds: 300,
+        isPrimeU: false,
+        isPrimeT: false,
+        isPrimeH: false,
+    };
+
+    const connectionValues = getConnectionValues([repeatedWord, uniqueWord], { U: true, T: true, H: true, Prime: false });
+    assert.equal(connectionValues.has(78), false);
+    assert.equal(connectionValues.has(51), false);
+    assert.equal(connectionValues.has(12), false);
+
+    const sharedAcrossWords = getConnectionValues([repeatedWord, { ...uniqueWord, units: 78 }], { U: true, T: true, H: true, Prime: false });
+    assert.equal(sharedAcrossWords.has(78), true);
 });


### PR DESCRIPTION
### Motivation
- Hover/highlight and the "קבוצות קשרים" count treated values repeated inside a single word (e.g. `78` in units/hundreds) as a shared connection, which caused incorrect perimeter coloring and group counts.
- A value should be considered a connection only when it appears in more than one distinct word, and hover coloring should reflect the strongest external connection, not self-sharing.
- Centralize the connection-detection logic so all consumers (app state and UI) use identical semantics.

### Description
- Added `getConnectionValues(words, filters)` to `src/core/wordConnections.js` which counts distinct words per visible value and returns only values present in multiple words.
- Replaced inline connection-counting logic in `src/state/appStore.jsx` and `src/App.jsx` to call `getConnectionValues(...)` so both providers share the same behavior.
- Removed now-unused imports and simplified provider code paths where appropriate.
- Added a regression test in `tests/wordConnections.test.js` verifying that repeated values inside one word do not count as a connection while the same value across two words does.

### Testing
- Ran the unit tests for the connection logic with `npm test -- tests/wordConnections.test.js` and all tests passed (4/4).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47b71f4488323801b0801f9569099)