### PR TITLE
Extract and reuse connection-value computation (getConnectionValues) and add tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,7 @@ import {
 } from './core/searchInput';
 import { useCoreResultsEngine } from './hooks/useCoreResultsEngine';
 import { useHebrewInputSanitizer } from './hooks/useHebrewInputSanitizer';
+import { getConnectionValues } from './core/wordConnections';
 
 // -----------------------------------------------------------------------------
 // 1. Context Definitions
@@ -696,7 +697,7 @@ const computeConnectedWordsSet = (activeWord, wordsByVisibleValue, visibleValues
     return connected;
 };
 
-const ClusterView = memo(({ clusterRefs, unpinOnBackgroundClick, filteredWordsInView, pinnedWord, hoveredWord, isDarkMode, primeColor, connectionValues, dispatch, copySummaryToClipboard, prepareSummaryCSV, copiedId, searchTerm }) => {
+const ClusterView = memo(({ clusterRefs, unpinOnBackgroundClick, filteredWordsInView, pinnedWord, hoveredWord, isDarkMode, primeColor, dispatch, copySummaryToClipboard, prepareSummaryCSV, copiedId, searchTerm }) => {
     const { filters } = useAppFilters();
     const searchInputRef = useRef(null);
     const deferredHoveredWord = useDeferredValue(hoveredWord);
@@ -704,6 +705,14 @@ const ClusterView = memo(({ clusterRefs, unpinOnBackgroundClick, filteredWordsIn
     const activeWordKey = activeWord?.word || null;
 
     const connectedWordsCacheRef = useRef(new Map());
+    const scopedWords = useMemo(
+        () => filteredWordsInView.flatMap(({ words }) => words),
+        [filteredWordsInView]
+    );
+    const scopedConnectionValues = useMemo(
+        () => getConnectionValues(scopedWords, filters),
+        [scopedWords, filters]
+    );
     useEffect(() => {
         connectedWordsCacheRef.current.clear();
     }, [filteredWordsInView, filters]);
@@ -789,7 +798,7 @@ const ClusterView = memo(({ clusterRefs, unpinOnBackgroundClick, filteredWordsIn
                                     isConnectedToActive={connectedWordsSet.has(wordData.word)}
                                     isDarkMode={isDarkMode}
                                     primeColor={primeColor}
-                                    connectionValues={connectionValues}
+                                    connectionValues={scopedConnectionValues}
                                     dispatch={dispatch}
                                     filters={filters}
                                 />
@@ -2968,7 +2977,6 @@ const App = () => {
                             hoveredWord={hoveredWord}
                             isDarkMode={isDarkMode}
                             primeColor={primeColor}
-                            connectionValues={connectionValues}
                             dispatch={dispatch}
                             copySummaryToClipboard={prepareSummaryText}
                             prepareSummaryCSV={prepareSummaryCSV}
@@ -3144,39 +3152,7 @@ function AppProvider({ children }) {
 
     const connectionValues = useMemo(() => {
          if (!state.coreResults) return new Set();
-         const visibleConnections = new Set();
-         const valueCounts = new Map();
-
-         state.coreResults.allWords.forEach((word) => {
-             const visibleValues = [];
-
-             if (word.hundreds !== word.tens && isValueVisible('H', word.isPrimeH, state.filters)) {
-                 visibleValues.push(word.hundreds);
-             }
-             if (word.tens !== word.units && isValueVisible('T', word.isPrimeT, state.filters)) {
-                 visibleValues.push(word.tens);
-             }
-             if (isValueVisible('U', word.isPrimeU, state.filters)) {
-                 visibleValues.push(word.units);
-             }
-
-             if (visibleValues.length === 0) return;
-
-             if (visibleValues.length > 1) {
-                 visibleValues.sort((a, b) => a - b);
-             }
-
-             let prevValue;
-             visibleValues.forEach((value) => {
-                 if (value === prevValue) return;
-                 const nextCount = (valueCounts.get(value) || 0) + 1;
-                 valueCounts.set(value, nextCount);
-                 if (nextCount > 1) visibleConnections.add(value);
-                 prevValue = value;
-             });
-         });
-
-         return visibleConnections;
+         return getConnectionValues(state.coreResults.allWords, state.filters);
     }, [state.coreResults, state.filters]);
 
     const contextValue = useMemo(() => ({

--- a/src/core/wordConnections.js
+++ b/src/core/wordConnections.js
@@ -71,3 +71,22 @@ export function computeConnectedWordsSet(activeWord, visibleValuesByWord, wordsB
 
     return connected;
 }
+
+export function getConnectionValues(words, filters) {
+    const valueToWordSet = new Map();
+
+    words.forEach((wordData) => {
+        const visibleValues = new Set(getVisibleValuesForWord(wordData, filters));
+        visibleValues.forEach((value) => {
+            if (!valueToWordSet.has(value)) valueToWordSet.set(value, new Set());
+            valueToWordSet.get(value).add(wordData.word);
+        });
+    });
+
+    const connectedValues = new Set();
+    valueToWordSet.forEach((wordSet, value) => {
+        if (wordSet.size > 1) connectedValues.add(value);
+    });
+
+    return connectedValues;
+}

--- a/src/state/appStore.jsx
+++ b/src/state/appStore.jsx
@@ -8,7 +8,8 @@ import React, {
     useRef,
     useTransition,
 } from 'react';
-import { computeCoreResults, getWordValues, isValueVisible } from '../core/analysisCore';
+import { computeCoreResults } from '../core/analysisCore';
+import { getConnectionValues } from '../core/wordConnections';
 import { appReducer, initialState } from './appReducer';
 
 const AppCoreContext = createContext(null);
@@ -127,25 +128,7 @@ const AppProvider = ({ children }) => {
 
     const connectionValues = useMemo(() => {
         if (!state.coreResults) return new Set();
-        const visibleConnections = new Set();
-        const valCounts = new Map();
-
-        state.coreResults.allWords.forEach((wordData) => {
-            const seenInWord = new Set();
-            const values = getWordValues(wordData);
-            values.forEach((valueData) => {
-                if (!isValueVisible(valueData.layer, valueData.isPrime, state.filters)) return;
-                if (seenInWord.has(valueData.value)) return;
-                seenInWord.add(valueData.value);
-                valCounts.set(valueData.value, (valCounts.get(valueData.value) || 0) + 1);
-            });
-        });
-
-        for (const [value, count] of valCounts.entries()) {
-            if (count > 1) visibleConnections.add(value);
-        }
-
-        return visibleConnections;
+        return getConnectionValues(state.coreResults.allWords, state.filters);
     }, [state.coreResults, state.filters]);
 
     const coreValue = useMemo(

--- a/tests/wordConnections.test.js
+++ b/tests/wordConnections.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { getVisibleValuesForWord, buildWordConnectionIndex, computeConnectedWordsSet } from '../src/core/wordConnections.js';
+import { getVisibleValuesForWord, buildWordConnectionIndex, computeConnectedWordsSet, getConnectionValues } from '../src/core/wordConnections.js';
 
 const wordA = {
     word: 'אב',
@@ -57,4 +57,33 @@ test('computeConnectedWordsSet returns words sharing visible values with active 
     assert.equal(connected.has('גד'), true);
     assert.equal(connected.has('הו'), false);
     assert.equal(connected.has('אב'), false);
+});
+
+test('getConnectionValues counts sharing across distinct words only', () => {
+    const repeatedWord = {
+        word: 'עח',
+        units: 78,
+        tens: 51,
+        hundreds: 78,
+        isPrimeU: false,
+        isPrimeT: false,
+        isPrimeH: false,
+    };
+    const uniqueWord = {
+        word: 'יחיד',
+        units: 12,
+        tens: 30,
+        hundreds: 300,
+        isPrimeU: false,
+        isPrimeT: false,
+        isPrimeH: false,
+    };
+
+    const connectionValues = getConnectionValues([repeatedWord, uniqueWord], { U: true, T: true, H: true, Prime: false });
+    assert.equal(connectionValues.has(78), false);
+    assert.equal(connectionValues.has(51), false);
+    assert.equal(connectionValues.has(12), false);
+
+    const sharedAcrossWords = getConnectionValues([repeatedWord, { ...uniqueWord, units: 78 }], { U: true, T: true, H: true, Prime: false });
+    assert.equal(sharedAcrossWords.has(78), true);
 });


### PR DESCRIPTION
### Motivation
- Centralize logic that determines which numeric values are shared across multiple words so the same criteria are used throughout the app.
- Replace duplicated, ad-hoc connection-counting logic with a single reusable function to simplify code and enable targeted testing.

### Description
- Added `getConnectionValues(words, filters)` to `src/core/wordConnections.js` which returns a `Set` of values that appear in more than one distinct word when respecting the supplied `filters`.
- Replaced inline connection-value/counting implementations in `src/App.jsx` and `src/state/appStore.jsx` to call `getConnectionValues`, and adjusted `ClusterView` to compute `scopedConnectionValues` for visible words via `getConnectionValues`.
- Imported `getConnectionValues` where needed and wired `WordCard` instances to use the scoped connection values in the cluster view.
- Extended `tests/wordConnections.test.js` to import and validate `getConnectionValues`, adding unit tests that assert values are only considered connected when shared across distinct words.

### Testing
- Ran the updated unit tests under `tests/wordConnections.test.js` which include existing connection-index tests plus new cases for `getConnectionValues`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f47b71f4488323801b0801f9569099)