### PR TITLE
Improve large-input textarea performance and stability

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1944,19 +1944,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
 
     useEffect(() => {
         adjustTextareaHeight();
-    }, [adjustTextareaHeight, textSize]);
-
-    useEffect(() => {
         applyTextareaRowBounds();
-    }, [applyTextareaRowBounds, textSize]);
-
-    useEffect(() => {
-        adjustTextareaHeight();
-    }, [adjustTextareaHeight, textSize]);
-
-    useEffect(() => {
-        applyTextareaRowBounds();
-    }, [applyTextareaRowBounds, textSize]);
+    }, [adjustTextareaHeight, applyTextareaRowBounds, textSize]);
 
     useEffect(() => () => clearCommitTimer(), [clearCommitTimer]);
 
@@ -2005,16 +1994,6 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         const key = e.key.toLowerCase();
         const isEnterKey = key === 'enter' || e.code === 'Enter' || e.code === 'NumpadEnter';
         const isSpaceKey = key === ' ' || key === 'space' || key === 'spacebar' || e.code === 'Space';
-
-        if (isMetaCombo && key === 'a') {
-            e.preventDefault();
-            e.stopPropagation();
-            const textarea = textareaRef.current;
-            if (!textarea) return;
-            textarea.focus();
-            textarea.setSelectionRange(0, textarea.value.length);
-            return;
-        }
 
         if (isMetaCombo && isEnterKey) {
             e.preventDefault();

--- a/src/hooks/useHebrewInputSanitizer.js
+++ b/src/hooks/useHebrewInputSanitizer.js
@@ -1,5 +1,12 @@
 import { useCallback } from 'react';
 
+const HEBREW_CHAR_RE = /^[א-ת]$/;
+const hasHebrewChar = (ch) => {
+  if (!ch || ch.length !== 1) return false;
+  const code = ch.charCodeAt(0);
+  return code >= 0x05D0 && code <= 0x05EA;
+};
+
 export function useHebrewInputSanitizer({
   HEB_MARKS_RE,
   INPUT_HEBREW_JOINERS_RE,
@@ -16,26 +23,26 @@ export function useHebrewInputSanitizer({
       .replace(INPUT_HEBREW_JOINERS_RE, '$1')
       .replace(INPUT_PUNCT_TO_SPACE_RE, ' ');
     const hasHebrewLetters = /[א-תךםןףץ]/.test(normalized);
-    let output = '';
+    const outputChars = [];
 
     for (const ch of normalized) {
-      if (ch === ' ' || ch === '\n' || /^[א-ת]$/.test(ch)) {
-        output += ch;
+      if (ch === ' ' || ch === '\n' || hasHebrewChar(ch)) {
+        outputChars.push(ch);
       } else {
         const lower = ch.toLowerCase();
         if (EN_TO_HE_LETTER_MAP[lower]) {
-          output += EN_TO_HE_LETTER_MAP[lower];
+          outputChars.push(EN_TO_HE_LETTER_MAP[lower]);
         } else if (!hasHebrewLetters && EN_TO_HE_PUNCT_LETTER_MAP[ch]) {
-          output += EN_TO_HE_PUNCT_LETTER_MAP[ch];
+          outputChars.push(EN_TO_HE_PUNCT_LETTER_MAP[ch]);
         } else if (!hasHebrewLetters && EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch]) {
-          output += EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch];
+          outputChars.push(EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch]);
         } else {
-          output += ' ';
+          outputChars.push(' ');
         }
       }
     }
 
-    return output
+    return outputChars.join('')
       .replace(INPUT_MULTI_SPACE_RE, ' ')
       .replace(/\n[ ]+/g, '\n');
   }, [
@@ -54,7 +61,7 @@ export function useHebrewInputSanitizer({
     .replace(INPUT_HEBREW_JOINERS_RE, '$1')
     .replace(INPUT_PUNCT_TO_SPACE_RE, ' ')
     .split('')
-    .filter((ch) => ch === ' ' || ch === '\n' || /^[א-ת]$/.test(ch))
+    .filter((ch) => ch === ' ' || ch === '\n' || HEBREW_CHAR_RE.test(ch))
     .join('')
     .replace(INPUT_MULTI_SPACE_RE, ' ')
     .replace(/\n[ ]+/g, '\n')


### PR DESCRIPTION
### Motivation

- The textarea and input sanitization were exhibiting slowdowns and occasional crashes when handling very large inputs (40k+ words), so the input pipeline and textarea event handling were optimized to reduce per-keystroke overhead and DOM layout churn.
- Improvements aim to keep existing sanitization and UX behavior while making large text editing and selection more robust and responsive.

### Description

- Rewrote the Hebrew input sanitizer to assemble output via a buffered array and a cheap code-point check (`hasHebrewChar`) instead of repeated string concatenation and regex tests to reduce CPU and GC pressure in `useHebrewInputSanitizer`.
- Added a `HEBREW_CHAR_RE` check for pasted text filtering and switched pasted sanitization to use that faster test, preserving previous filtering semantics.
- Consolidated duplicate textarea sizing effects into a single `useEffect` that calls both `adjustTextareaHeight` and `applyTextareaRowBounds` to avoid redundant layout/reflow work in `MainTextInput` (`src/App.jsx`).
- Removed the custom Ctrl/Cmd+A interception in the textarea key handler so native browser `select all` is used for large buffers, and retained the `Ctrl/Cmd+Enter` commit shortcut and other existing key mappings.

### Testing

- Ran the full unit test suite with `npm run test -- --test-reporter=spec`, all tests passed (`32` tests passed).
- Built the production bundle with `npm run build`, which completed successfully and produced the app assets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49d60e41c8323ad883033e68ad4e3)