### PR TITLE
Simplify stats tiles, make primes panel keyboard-accessible, and small UI text/styling tweaks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -542,14 +542,6 @@ const StatsPanel = memo(() => {
     const dispatch = useAppDispatch();
     if (!stats) return null;
 
-    const colorClasses = {
-        blue:	{ boxLight: 'bg-blue-50 border-blue-200', text: 'text-blue-800', boxDark: 'bg-gray-700/50 border-blue-800' },
-        indigo: { boxLight: 'bg-indigo-50 border-indigo-200', text: 'text-indigo-800', boxDark: 'bg-gray-700/50 border-indigo-800' },
-        purple: { boxLight: 'bg-purple-50 border-purple-200', text: 'text-purple-800', boxDark: 'bg-gray-700/50 border-purple-800' },
-        emerald:{ boxLight: 'bg-emerald-50 border-emerald-200', text: 'text-emerald-800', boxDark: 'bg-gray-700/50 border-emerald-800' },
-        pink:	{ boxLight: 'bg-pink-50 border-pink-200', text: 'text-pink-800', boxDark: 'bg-gray-700/50 border-pink-800' },
-    };
-
     return (
         <div className={`p-6 rounded-xl border mb-8 ${isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-slate-50/95 border-slate-300 shadow-[0_18px_45px_-30px_rgba(15,23,42,0.7)]'}`}>
             <button onClick={() => dispatch({ type: 'TOGGLE_STATS_COLLAPSED' })} className="w-full flex justify-between items-center text-2xl font-bold text-gray-800 dark:text-gray-200 noselect">
@@ -559,15 +551,12 @@ const StatsPanel = memo(() => {
             </button>
             {!isStatsCollapsed && (
                 <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-center my-6">
-                    {[{label: 'סה"כ שורות', value: stats.totalLines, color: 'blue'}, {label: 'סה"כ מילים', value: stats.totalWords, color: 'indigo'}, {label: 'מילים ייחודיות', value: stats.uniqueWords, color: 'purple'}, {label: 'שורות ראשוניות', value: stats.primeLineTotals, color: 'emerald'}, {label: 'קבוצות קשרים', value: connectionValues.size, color: 'pink'}].map(item => {
-                        const cls = colorClasses[item.color];
-                        return (
-                            <div key={item.label} className={`p-4 rounded-lg border noselect cursor-default ${isDarkMode ? cls.boxDark : cls.boxLight}`}>
-                                <p className={`text-sm ${isDarkMode ? 'text-gray-300' : cls.text} font-semibold`}>{item.label}</p>
-                                <p className={`text-3xl font-bold ${isDarkMode ? 'text-gray-100' : cls.text}`}>{item.value}</p>
-                            </div>
-                        );
-                    })}
+                    {[{label: 'סה"כ שורות', value: stats.totalLines}, {label: 'סה"כ מילים', value: stats.totalWords}, {label: 'מילים ייחודיות', value: stats.uniqueWords}, {label: 'שורות ראשוניות', value: stats.primeLineTotals}, {label: 'קבוצות קשרים', value: connectionValues.size}].map(item => (
+                        <div key={item.label} className="p-4 rounded-lg bg-slate-200 dark:bg-gray-700/50 noselect cursor-default">
+                            <p className="text-sm text-gray-700 dark:text-gray-300 font-semibold">{item.label}</p>
+                            <p className="text-3xl font-bold text-slate-900 dark:text-gray-100">{item.value}</p>
+                        </div>
+                    ))}
                 </div>
             )}
         </div>
@@ -2828,11 +2817,31 @@ const App = () => {
                                         </div>
                                     )}
                                     {coreResults.primeSummary.length > 0 && (
-                                        <div className={`p-4 sm:p-6 rounded-xl border mb-8 ${isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-slate-50/95 border-slate-300 shadow-[0_18px_45px_-30px_rgba(15,23,42,0.7)]'}`}>
-                                            <button onClick={() => dispatch({ type: 'TOGGLE_PRIMES_COLLAPSED' })} className="w-full flex justify-between items-center text-2xl font-bold text-gray-800 dark:text-gray-200 noselect">
-                                                <span className="text-center flex-grow">{stats.primeLineTotals} שורות ראשוניות</span>
-                                                <Icon name="chevron-down" className={`w-6 h-6 transition-transform duration-300 ${isPrimesCollapsed ? '' : 'rotate-180'}`} />
-                                            </button>
+                                        <div
+                                            className={`relative p-4 sm:p-6 rounded-xl border mb-8 cursor-pointer ${isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-slate-50/95 border-slate-300 shadow-[0_18px_45px_-30px_rgba(15,23,42,0.7)]'}`}
+                                            onClick={() => dispatch({ type: 'TOGGLE_PRIMES_COLLAPSED' })}
+                                            aria-label="הצג או הסתר פירוט ערכים ראשוניים"
+                                            role="button"
+                                            tabIndex={0}
+                                            onKeyDown={(event) => {
+                                                if (event.key === 'Enter' || event.key === ' ') {
+                                                    event.preventDefault();
+                                                    dispatch({ type: 'TOGGLE_PRIMES_COLLAPSED' });
+                                                }
+                                            }}
+                                        >
+                                            <Icon name="chevron-down" className={`absolute top-4 left-4 w-6 h-6 text-gray-800 dark:text-gray-200 transition-transform duration-300 ${isPrimesCollapsed ? '' : 'rotate-180'}`} />
+                                            <h2 className="text-2xl font-bold text-center mb-4 text-gray-800 dark:text-gray-200 noselect">מדדי ראשוניות שורות</h2>
+                                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4 text-center">
+                                                <div className="p-4 rounded-lg bg-slate-200 dark:bg-gray-700/50">
+                                                    <p className="text-sm text-gray-700 dark:text-gray-300 font-semibold">שורות ראשוניות</p>
+                                                    <p className="text-3xl font-bold text-slate-900 dark:text-gray-100">{stats.primeLineTotals}</p>
+                                                </div>
+                                                <div className="p-4 rounded-lg bg-slate-200 dark:bg-gray-700/50">
+                                                    <p className="text-sm text-gray-700 dark:text-gray-300 font-semibold">ערכים ראשוניים</p>
+                                                    <p className="text-3xl font-bold text-slate-900 dark:text-gray-100">{coreResults.primeSummary.length}</p>
+                                                </div>
+                                            </div>
                                             {!isPrimesCollapsed && (
                                                 <div className="mt-4">
                                                     <div className="overflow-x-auto max-w-lg mx-auto">
@@ -2866,7 +2875,7 @@ const App = () => {
                                                 style={{ contentVisibility: 'auto', containIntrinsicSize: '560px' }}
                                             >
                                                 <div className="cursor-pointer" onClick={() => dispatch({ type: 'TOGGLE_ROW_EXPAND', payload: lineIndex })}>
-                                                    <div className="flex justify-between items-center"><h2 className="text-2xl font-bold mb-1 text-center flex-grow">תוצאות עבור שורה {lineIndex + 1}</h2><Icon name="chevron-down" className={`w-6 h-6 transition-transform duration-300 ${isExpanded ? 'rotate-180' : ''}`} /></div>
+                                                    <div className="flex justify-between items-center"><h2 className="text-2xl font-bold mb-1 text-center flex-grow">שורה {lineIndex + 1}</h2><Icon name="chevron-down" className={`w-6 h-6 transition-transform duration-300 ${isExpanded ? 'rotate-180' : ''}`} /></div>
                                                     <p className={`text-center mb-6 italic text-lg break-all ${isDarkMode ? 'text-gray-400' : 'text-gray-700'}`}>"{lineResult.lineText}"</p>
                                                     {showTotalsLine && <div className={`font-bold text-sm text-center p-2 rounded-lg ${isDarkMode ? 'bg-gray-700 text-gray-100' : 'bg-slate-200 text-gray-900'}`}>סה"כ שורה: 
                                                         {lineResult.words.length > 1 && <span className="mx-2">({lineResult.words.length} מילים)</span>}


### PR DESCRIPTION
### Motivation
- Reduce visual complexity of the statistics tiles by removing per-tile color variants and use a consistent, theme-aware style.
- Improve accessibility and discoverability of the primes summary by making the panel clickable and keyboard-toggleable with appropriate ARIA attributes.
- Minor UI/label cleanup to make headings shorter and unify visual treatments.

### Description
- Removed the `colorClasses` mapping and simplified the stats tiles rendering to use uniform `bg-slate-200 dark:bg-gray-700/50` tiles with consistent text classes.
- Reworked the primes summary block into a single clickable container with `role="button"`, `aria-label`, `tabIndex`, and `onKeyDown` handling so the panel can be toggled with Enter/Space, and moved the chevron icon to an absolute position while adding a compact summary header and two summary tiles.
- Shortened the per-line heading text from `תוצאות עבור שורה X` to `שורה X` and adjusted related styling for consistency.
- Applied small styling adjustments across summary and totals tiles to use consistent background/text colors in both light and dark themes.

### Testing
- Ran the project's test suite with `yarn test`; unit tests passed.
- Built the application with `yarn build` to verify no build regressions; the build succeeded.
- Ran basic linting (`yarn lint`) and static checks; no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9958e26408323a57819a86155f5f2)