### PR TITLE
Add consistent legend header to clipboard exports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, useRef, useCallback, useDeferredValue, useTransition, useLayoutEffect, useReducer, useContext, createContext, memo } from 'react';
 import VirtualizedList from './components/VirtualizedList';
-import { stripTrailingSpacesPerLine } from './utils/exportFormatting';
+import { formatTextForClipboard, stripTrailingSpacesPerLine } from './utils/exportFormatting';
 import { matchesSearchQuery } from './core/searchQuery';
 import {
     BASE_LETTER_VALUES,
@@ -465,7 +465,7 @@ const ExportToolbar = ({ getText, getCSV, id, label = "העתק" }) => {
         await new Promise(resolve => setTimeout(resolve, 10)); 
 
         try {
-            const text = stripTrailingSpacesPerLine(getText());
+            const text = formatTextForClipboard(getText());
             if (!text || text.trim().length === 0) throw new Error("No visible text generated based on current filters");
             
             let success = false;

--- a/src/utils/exportFormatting.js
+++ b/src/utils/exportFormatting.js
@@ -5,3 +5,18 @@ export function stripTrailingSpacesPerLine(text) {
     .map((line) => line.replace(/[ \t]+$/g, ''))
     .join('\n');
 }
+
+
+export const COPY_LAYER_LEGEND = "א'-אחדות ע'-עשרות מ'-מאות";
+export const COPY_PRIME_LEGEND = "♢-ראשוני";
+
+export function formatTextForClipboard(text) {
+  const cleaned = stripTrailingSpacesPerLine(text);
+  if (!cleaned) return '';
+
+  const normalized = cleaned.trimStart();
+  const headerLine = `${COPY_LAYER_LEGEND} ${COPY_PRIME_LEGEND}`;
+  if (normalized.startsWith(headerLine)) return cleaned;
+
+  return `${headerLine}\n---\n\n${cleaned}`;
+}

--- a/tests/exportFormatting.test.js
+++ b/tests/exportFormatting.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { stripTrailingSpacesPerLine } from '../src/utils/exportFormatting.js';
+import { formatTextForClipboard, stripTrailingSpacesPerLine } from '../src/utils/exportFormatting.js';
 
 test('stripTrailingSpacesPerLine removes trailing single spaces and tabs per line', () => {
     const input = 'first line \nsecond\t\nthird   ';
@@ -17,4 +17,15 @@ test('stripTrailingSpacesPerLine keeps internal spaces and line breaks', () => {
 test('stripTrailingSpacesPerLine handles non-string inputs safely', () => {
     assert.equal(stripTrailingSpacesPerLine(null), '');
     assert.equal(stripTrailingSpacesPerLine(undefined), '');
+});
+
+
+test('formatTextForClipboard prepends legend header to copied text', () => {
+    const output = formatTextForClipboard('מצב חישוב: א:0');
+    assert.equal(output, "א'-אחדות ע'-עשרות מ'-מאות ♢-ראשוני\n---\n\nמצב חישוב: א:0");
+});
+
+test('formatTextForClipboard avoids duplicating legend if already present', () => {
+    const input = "א'-אחדות ע'-עשרות מ'-מאות ♢-ראשוני\n---\n\nטקסט";
+    assert.equal(formatTextForClipboard(input), input);
 });


### PR DESCRIPTION
### Motivation
- Ensure every clipboard copy from the app includes a clear legend header `א'-אחדות ע'-עשרות מ'-מאות ♢-ראשוני` and a separator so pasted data is self-explanatory.
- Prevent duplicate header insertion when the source text already contains the legend.

### Description
- Added `COPY_LAYER_LEGEND`, `COPY_PRIME_LEGEND` and a new `formatTextForClipboard` helper to `src/utils/exportFormatting.js` that prepends the legend and `---` separator while avoiding duplication.
- Updated `ExportToolbar` in `src/App.jsx` to use `formatTextForClipboard` for the copy flow so all `העתק` actions reuse the shared formatter.
- Kept CSV export behavior unchanged while ensuring copied text now includes the unified header.
- Added unit tests in `tests/exportFormatting.test.js` covering header insertion and duplicate-avoidance.

### Testing
- Ran `npm test -- tests/exportFormatting.test.js` and all tests passed (`5` passed, `0` failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6850d8388323bbc188236419addf)