### PR TITLE
Aggregate detail exports by line and normalize JSON output

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2613,9 +2613,18 @@ const App = () => {
         const rows = [];
         coreResults?.lines.forEach((line, index) => {
             const visibleWords = visibleWordsByLine[index] || [];
-            visibleWords.forEach((w) => rows.push([mode, index + 1, line.lineText, w.word, w.dr, w.units, w.tens, w.hundreds, w.isPrimeU ? 1 : 0, w.isPrimeT ? 1 : 0, w.isPrimeH ? 1 : 0]));
+            rows.push([
+                mode,
+                index + 1,
+                visibleWords.length,
+                visibleWords.map((w) => w.word).join('|'),
+                visibleWords.map((w) => `${w.word}:${w.dr}`).join('|'),
+                visibleWords.map((w) => `${w.word}:${w.units}`).join('|'),
+                visibleWords.map((w) => `${w.word}:${w.tens}`).join('|'),
+                visibleWords.map((w) => `${w.word}:${w.hundreds}`).join('|'),
+            ]);
         });
-        return toCSV(['mode','line_number','line_text','word','dr','units','tens','hundreds','is_prime_u','is_prime_t','is_prime_h'], rows);
+        return toCSV(['mode','line_number','word_count','words','dr_by_word','units_by_word','tens_by_word','hundreds_by_word'], rows);
     }, [detailsView, visibleAllWords, mode, coreResults, visibleWordsByLine, toCSV]);
 
     const prepareSummaryText = useCallback(() => {
@@ -2713,7 +2722,19 @@ const App = () => {
         return toCSV(['mode','type','word','count'], sortedHotViewList.map(({ word, count }) => [mode, 'word', word, count]));
     }, [hotView, sortedHotViewList, visibleValueToWordsMap, toCSV, mode]);
 
-    const prepareAllDetailsJSON = useCallback(() => JSON.stringify({ mode, detailsView, selectedDR, words: visibleAllWords }, null, 2), [mode, detailsView, selectedDR, visibleAllWords]);
+    const prepareAllDetailsJSON = useCallback(() => {
+        if (detailsView === 'words') {
+            return JSON.stringify({ mode, detailsView, selectedDR, words: visibleAllWords }, null, 2);
+        }
+
+        const lines = (coreResults?.lines || []).map((line, index) => ({
+            lineNumber: index + 1,
+            lineText: line.lineText,
+            words: visibleWordsByLine[index] || [],
+        }));
+
+        return JSON.stringify({ mode, detailsView, selectedDR, lines }, null, 2);
+    }, [mode, detailsView, selectedDR, visibleAllWords, coreResults, visibleWordsByLine]);
     const prepareSummaryJSON = useCallback(() => JSON.stringify({ mode, view, selectedDR, searchTerm, pinnedWord: pinnedWord?.word ?? null, clusters: filteredWordsInView }, null, 2), [mode, view, selectedDR, searchTerm, pinnedWord, filteredWordsInView]);
     const prepareHotWordsJSON = useCallback(() => JSON.stringify({ mode, selectedHotValue, words: visibleHotWords }, null, 2), [mode, selectedHotValue, visibleHotWords]);
     const prepareFrequenciesJSON = useCallback(() => JSON.stringify({ mode, hotView, rows: sortedHotViewList }, null, 2), [mode, hotView, sortedHotViewList]);


### PR DESCRIPTION
### Motivation

- Make the "All Details" CSV and JSON exports more useful by aggregating word-level data per source line instead of emitting one row per visible word.
- Reduce CSV column noise by bundling per-word fields into pipe-delimited columns for easier analysis and download.
- Provide a consistent JSON shape for both `words` and `lines` detail views to simplify downstream consumers.

### Description

- Updated `prepareAllDetailsCSV` to emit one row per source line with columns `mode`, `line_number`, `word_count`, `words`, `dr_by_word`, `units_by_word`, `tens_by_word`, and `hundreds_by_word` where per-word values are pipe-delimited strings of `word` or `word:value` pairs. 
- Adjusted the CSV header passed to `toCSV` to match the new aggregated columns and removed per-word `is_prime_*` columns from this export. 
- Reworked `prepareAllDetailsJSON` to return a detailed `lines` array when `detailsView !== 'words'`, where each entry includes `lineNumber`, `lineText`, and `words` (from `visibleWordsByLine`), while preserving the previous `words` shape when `detailsView === 'words'`.
- Kept other summary/export helpers unchanged and ensured the new outputs are produced via their existing callback hooks.

### Testing

- Ran linting with `npm run lint` and it completed successfully. 
- Ran the test suite with `npm test` and all tests passed. 
- Built the application with `npm run build` to verify bundling and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e5d9f3708323bbac228966f1d8f2)