### PR TITLE
Support IME composition in MainTextInput and refine textarea resize handle styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1890,6 +1890,7 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
     const draftRef = useRef(text);
     const commitTimerRef = useRef(null);
     const dragStateRef = useRef(null);
+    const isComposingRef = useRef(false);
     const minTextareaHeightRef = useRef(0);
     const maxTextareaHeightRef = useRef(Number.POSITIVE_INFINITY);
     const [isDragActive, setIsDragActive] = useState(false);
@@ -1984,6 +1985,12 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
 
     const handleChange = useCallback((e) => {
         const rawValue = e.target.value;
+
+        if (isComposingRef.current) {
+            draftRef.current = rawValue;
+            adjustTextareaHeight(e.target);
+            return;
+        }
         const nativeInputEvent = e.nativeEvent;
         const inputType = nativeInputEvent?.inputType || '';
         const insertedData = nativeInputEvent?.data ?? null;
@@ -2008,6 +2015,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
     }, [adjustTextareaHeight, sanitizeHebrewInput, scheduleCommit]);
 
     const handleKeyDown = useCallback((e) => {
+        if (isComposingRef.current || e.nativeEvent?.isComposing) return;
+
         const isMetaCombo = e.ctrlKey || e.metaKey;
         const key = e.key.toLowerCase();
         const isEnterKey = key === 'enter' || e.code === 'Enter' || e.code === 'NumpadEnter';
@@ -2111,6 +2120,28 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         requestAnimationFrame(() => textarea.setSelectionRange(nextPos, nextPos));
     }, [adjustTextareaHeight, sanitizePastedHebrewInput, scheduleCommit]);
 
+
+
+    const handleCompositionStart = useCallback(() => {
+        isComposingRef.current = true;
+    }, []);
+
+    const handleCompositionEnd = useCallback((e) => {
+        isComposingRef.current = false;
+        const finalizedValue = sanitizeHebrewInput(e.currentTarget.value);
+
+        if (finalizedValue !== e.currentTarget.value) {
+            const cursorStart = e.currentTarget.selectionStart ?? e.currentTarget.value.length;
+            const nextCursor = sanitizeHebrewInput(e.currentTarget.value.slice(0, cursorStart)).length;
+            e.currentTarget.value = finalizedValue;
+            requestAnimationFrame(() => e.currentTarget.setSelectionRange(nextCursor, nextCursor));
+        }
+
+        draftRef.current = finalizedValue;
+        adjustTextareaHeight(e.currentTarget);
+        scheduleCommit(finalizedValue);
+    }, [adjustTextareaHeight, sanitizeHebrewInput, scheduleCommit]);
+
     const handleDragOver = useCallback((e) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'copy';
@@ -2180,7 +2211,7 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
     useEffect(() => () => stopResizeDrag(), [stopResizeDrag]);
 
     return (
-        <div className="relative">
+        <div className="relative pb-3">
             <textarea
                 ref={textareaRef}
                 dir="rtl"
@@ -2193,6 +2224,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
                 onBlur={commitChanges}
                 onKeyDown={handleKeyDown}
                 onPaste={handlePaste}
+                onCompositionStart={handleCompositionStart}
+                onCompositionEnd={handleCompositionEnd}
                 onDragOver={handleDragOver}
                 onDragLeave={handleDragLeave}
                 onDrop={handleDrop}
@@ -2204,8 +2237,9 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
             />
             <div
                 role="presentation"
-                className="absolute bottom-0 left-0 right-0 h-4 cursor-ns-resize"
+                className="absolute bottom-0 left-0 right-0 h-2 cursor-ns-resize rounded-b-lg bg-slate-300/90 dark:bg-gray-600/90"
                 onMouseDown={beginResizeDrag}
+                aria-hidden="true"
             />
         </div>
     );


### PR DESCRIPTION
### Motivation
- Prevent mid-composition sanitization and cursor jumps when using IME/complex input (e.g. Hebrew composition) and ensure the finalized composed text is correctly sanitized and committed.
- Improve the textarea resize handle appearance and layout to avoid overlap with content and make the handle visually distinct.

### Description
- Introduce `isComposingRef` and add `onCompositionStart`/`onCompositionEnd` handlers to the main textarea to track IME composition state and finalize sanitization on composition end.
- Update `handleChange` to skip sanitization and height adjustments while composing, and update `handleKeyDown` to ignore key handling during composition or when `nativeEvent.isComposing` is set.
- In `handleCompositionEnd` sanitize the finalized value, correct the caret position if needed, update `draftRef`, adjust textarea height, and schedule a commit via the existing `scheduleCommit` flow.
- Add `pb-3` to the textarea container and restyle the resize handle with `h-2 rounded-b-lg bg-slate-300/90 dark:bg-gray-600/90` and `aria-hidden="true"` for visual and layout improvements.

### Testing
- Ran the project test suite with `yarn test`, and the tests passed.
- Built the production bundle with `yarn build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a007e74c9cc8323947833b02f743211)