### PR TITLE
Improve Hebrew input sanitization and textarea input handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1944,19 +1944,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
 
     useEffect(() => {
         adjustTextareaHeight();
-    }, [adjustTextareaHeight, textSize]);
-
-    useEffect(() => {
         applyTextareaRowBounds();
-    }, [applyTextareaRowBounds, textSize]);
-
-    useEffect(() => {
-        adjustTextareaHeight();
-    }, [adjustTextareaHeight, textSize]);
-
-    useEffect(() => {
-        applyTextareaRowBounds();
-    }, [applyTextareaRowBounds, textSize]);
+    }, [adjustTextareaHeight, applyTextareaRowBounds, textSize]);
 
     useEffect(() => () => clearCommitTimer(), [clearCommitTimer]);
 
@@ -1981,10 +1970,15 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         const inputType = nativeInputEvent?.inputType || '';
         const insertedData = nativeInputEvent?.data ?? null;
         const isDeleteInput = inputType.startsWith('delete');
-        const isSimpleInsert = inputType === 'insertText' || inputType === 'insertLineBreak';
+        const isSimpleInsert = inputType === 'insertText';
+        const isLineBreakInsert = inputType === 'insertLineBreak';
         const isLargeInput = rawValue.length > LARGE_INPUT_SANITIZE_THRESHOLD;
         const isAllowedInsertedData = insertedData === null || insertedData === '\n' || insertedData === ' ' || /^[א-ת]$/.test(insertedData);
-        const canSkipFullSanitize = isLargeInput && (isDeleteInput || isSimpleInsert || isAllowedInsertedData);
+        const canSkipFullSanitize = isLargeInput && (
+            isDeleteInput
+            || isLineBreakInsert
+            || (isSimpleInsert && isAllowedInsertedData)
+        );
 
         const nextValue = canSkipFullSanitize ? rawValue : sanitizeHebrewInput(rawValue);
 
@@ -2005,16 +1999,6 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         const key = e.key.toLowerCase();
         const isEnterKey = key === 'enter' || e.code === 'Enter' || e.code === 'NumpadEnter';
         const isSpaceKey = key === ' ' || key === 'space' || key === 'spacebar' || e.code === 'Space';
-
-        if (isMetaCombo && key === 'a') {
-            e.preventDefault();
-            e.stopPropagation();
-            const textarea = textareaRef.current;
-            if (!textarea) return;
-            textarea.focus();
-            textarea.setSelectionRange(0, textarea.value.length);
-            return;
-        }
 
         if (isMetaCombo && isEnterKey) {
             e.preventDefault();

--- a/src/hooks/useHebrewInputSanitizer.js
+++ b/src/hooks/useHebrewInputSanitizer.js
@@ -1,5 +1,12 @@
 import { useCallback } from 'react';
 
+const HEBREW_CHAR_RE = /^[א-ת]$/;
+const hasHebrewChar = (ch) => {
+  if (!ch || ch.length !== 1) return false;
+  const code = ch.charCodeAt(0);
+  return code >= 0x05D0 && code <= 0x05EA;
+};
+
 export function useHebrewInputSanitizer({
   HEB_MARKS_RE,
   INPUT_HEBREW_JOINERS_RE,
@@ -16,26 +23,26 @@ export function useHebrewInputSanitizer({
       .replace(INPUT_HEBREW_JOINERS_RE, '$1')
       .replace(INPUT_PUNCT_TO_SPACE_RE, ' ');
     const hasHebrewLetters = /[א-תךםןףץ]/.test(normalized);
-    let output = '';
+    const outputChars = [];
 
     for (const ch of normalized) {
-      if (ch === ' ' || ch === '\n' || /^[א-ת]$/.test(ch)) {
-        output += ch;
+      if (ch === ' ' || ch === '\n' || hasHebrewChar(ch)) {
+        outputChars.push(ch);
       } else {
         const lower = ch.toLowerCase();
         if (EN_TO_HE_LETTER_MAP[lower]) {
-          output += EN_TO_HE_LETTER_MAP[lower];
+          outputChars.push(EN_TO_HE_LETTER_MAP[lower]);
         } else if (!hasHebrewLetters && EN_TO_HE_PUNCT_LETTER_MAP[ch]) {
-          output += EN_TO_HE_PUNCT_LETTER_MAP[ch];
+          outputChars.push(EN_TO_HE_PUNCT_LETTER_MAP[ch]);
         } else if (!hasHebrewLetters && EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch]) {
-          output += EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch];
+          outputChars.push(EN_TO_HE_SHIFTED_PUNCT_LETTER_MAP[ch]);
         } else {
-          output += ' ';
+          outputChars.push(' ');
         }
       }
     }
 
-    return output
+    return outputChars.join('')
       .replace(INPUT_MULTI_SPACE_RE, ' ')
       .replace(/\n[ ]+/g, '\n');
   }, [
@@ -54,7 +61,7 @@ export function useHebrewInputSanitizer({
     .replace(INPUT_HEBREW_JOINERS_RE, '$1')
     .replace(INPUT_PUNCT_TO_SPACE_RE, ' ')
     .split('')
-    .filter((ch) => ch === ' ' || ch === '\n' || /^[א-ת]$/.test(ch))
+    .filter((ch) => ch === ' ' || ch === '\n' || HEBREW_CHAR_RE.test(ch))
     .join('')
     .replace(INPUT_MULTI_SPACE_RE, ' ')
     .replace(/\n[ ]+/g, '\n')


### PR DESCRIPTION
### Motivation
- Fix correctness and performance of Hebrew input sanitization and pasted-input filtering by using a precise Hebrew character check and avoiding repeated string concatenation. 
- Reduce redundant effect invocations that could cause extra layout work and make input handling more predictable. 
- Allow skipping expensive sanitization for large inputs on safe operations (including line breaks) to improve responsiveness. 
- Remove a custom meta+A handler to avoid interfering with default browser selection behavior.

### Description
- Add `HEBREW_CHAR_RE` and `hasHebrewChar` and replace ad-hoc `/^[א-ת]$/` checks with these helpers in `useHebrewInputSanitizer.js` to robustly detect Hebrew characters. 
- Replace incremental string concatenation with an `outputChars` array and `join` in `sanitizeHebrewInput` to reduce allocations and improve performance. 
- Tighten `sanitizePastedHebrewInput` filtering to use `HEBREW_CHAR_RE` for single-character checks. 
- Consolidate and deduplicate `useEffect` dependencies in `App.jsx` to prevent duplicate calls to `adjustTextareaHeight` and `applyTextareaRowBounds`. 
- Refine input handling in `App.jsx` by splitting `isLineBreakInsert` from `isSimpleInsert`, and update `canSkipFullSanitize` logic to allow skipping full sanitize on deletes, explicit line-break inserts, or simple inserts with allowed characters. 
- Remove the custom `meta+A` select-all interception from `handleKeyDown` to let the browser handle selection natively.

### Testing
- Ran the unit test suite with `npm test`, which completed successfully. 
- Ran the linter with `npm run lint`, which reported no errors. 
- Built the project with `npm run build`, and the production build completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49d60e41c8323ad883033e68ad4e3)