### PR TITLE
Use cancellable RAF to schedule textarea selection updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1889,6 +1889,7 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
     const textareaRef = useRef(null);
     const draftRef = useRef(text);
     const commitTimerRef = useRef(null);
+    const selectionRafRef = useRef(null);
     const dragStateRef = useRef(null);
     const isComposingRef = useRef(false);
     const minTextareaHeightRef = useRef(0);
@@ -1910,6 +1911,20 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         if (commitTimerRef.current !== null) {
             clearTimeout(commitTimerRef.current);
             commitTimerRef.current = null;
+        }
+    }, []);
+
+    const queueSelectionUpdate = useCallback((fn) => {
+        if (selectionRafRef.current !== null) cancelAnimationFrame(selectionRafRef.current);
+        selectionRafRef.current = requestAnimationFrame(() => {
+            selectionRafRef.current = null;
+            fn();
+        });
+    }, []);
+    const clearSelectionUpdate = useCallback(() => {
+        if (selectionRafRef.current !== null) {
+            cancelAnimationFrame(selectionRafRef.current);
+            selectionRafRef.current = null;
         }
     }, []);
 
@@ -1957,16 +1972,19 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         if (isFocused) {
             const nextStart = Math.min(selectionStart, sanitized.length);
             const nextEnd = Math.min(selectionEnd, sanitized.length);
-            requestAnimationFrame(() => textarea.setSelectionRange(nextStart, nextEnd));
+            queueSelectionUpdate(() => textarea.setSelectionRange(nextStart, nextEnd));
         }
-    }, [adjustTextareaHeight, sanitizeHebrewInput, text]);
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizeHebrewInput, text]);
 
     useEffect(() => {
         adjustTextareaHeight();
         applyTextareaRowBounds();
     }, [adjustTextareaHeight, applyTextareaRowBounds, textSize]);
 
-    useEffect(() => () => clearCommitTimer(), [clearCommitTimer]);
+    useEffect(() => () => {
+        clearCommitTimer();
+        clearSelectionUpdate();
+    }, [clearCommitTimer, clearSelectionUpdate]);
 
     const scheduleCommit = useCallback((nextValue) => {
         clearCommitTimer();
@@ -2011,13 +2029,13 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
             const cursorStart = e.target.selectionStart ?? rawValue.length;
             const nextCursor = sanitizeHebrewInput(rawValue.slice(0, cursorStart)).length;
             e.target.value = nextValue;
-            requestAnimationFrame(() => e.target.setSelectionRange(nextCursor, nextCursor));
+            queueSelectionUpdate(() => e.target.setSelectionRange(nextCursor, nextCursor));
         }
 
         draftRef.current = nextValue;
         adjustTextareaHeight(e.target);
         scheduleCommit(nextValue);
-    }, [adjustTextareaHeight, sanitizeHebrewInput, scheduleCommit]);
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizeHebrewInput, scheduleCommit]);
 
     const handleKeyDown = useCallback((e) => {
         if (isComposingRef.current || e.nativeEvent?.isComposing) return;
@@ -2042,6 +2060,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         if (isMetaCombo || e.altKey || key === 'shift' || key === 'alt' || key === 'control' || key === 'meta') {
             return;
         }
+
+        clearSelectionUpdate();
 
         if (isEnterKey || isSpaceKey) {
             return;
@@ -2074,14 +2094,14 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
             scheduleCommit(nextValue);
 
             const nextPos = start + mappedLetter.length;
-            requestAnimationFrame(() => textarea.setSelectionRange(nextPos, nextPos));
+            queueSelectionUpdate(() => textarea.setSelectionRange(nextPos, nextPos));
             return;
         }
 
         if (!/^[א-ת]$/i.test(e.key)) {
             e.preventDefault();
         }
-    }, [adjustTextareaHeight, commitChanges, scheduleCommit]);
+    }, [adjustTextareaHeight, clearSelectionUpdate, commitChanges, queueSelectionUpdate, scheduleCommit]);
 
     const handlePaste = useCallback((e) => {
         const pasted = e.clipboardData?.getData('text') ?? '';
@@ -2103,8 +2123,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         scheduleCommit(nextValue);
 
         const nextPos = start + sanitized.length;
-        requestAnimationFrame(() => textarea.setSelectionRange(nextPos, nextPos));
-    }, [adjustTextareaHeight, sanitizePastedHebrewInput, scheduleCommit]);
+        queueSelectionUpdate(() => textarea.setSelectionRange(nextPos, nextPos));
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizePastedHebrewInput, scheduleCommit]);
 
     const insertTextAtCursor = useCallback((incomingText) => {
         const textarea = textareaRef.current;
@@ -2122,8 +2142,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         scheduleCommit(nextValue);
 
         const nextPos = start + sanitized.length;
-        requestAnimationFrame(() => textarea.setSelectionRange(nextPos, nextPos));
-    }, [adjustTextareaHeight, sanitizePastedHebrewInput, scheduleCommit]);
+        queueSelectionUpdate(() => textarea.setSelectionRange(nextPos, nextPos));
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizePastedHebrewInput, scheduleCommit]);
 
 
 
@@ -2139,13 +2159,13 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
             const cursorStart = e.currentTarget.selectionStart ?? e.currentTarget.value.length;
             const nextCursor = sanitizeHebrewInput(e.currentTarget.value.slice(0, cursorStart)).length;
             e.currentTarget.value = finalizedValue;
-            requestAnimationFrame(() => e.currentTarget.setSelectionRange(nextCursor, nextCursor));
+            queueSelectionUpdate(() => e.currentTarget.setSelectionRange(nextCursor, nextCursor));
         }
 
         draftRef.current = finalizedValue;
         adjustTextareaHeight(e.currentTarget);
         scheduleCommit(finalizedValue);
-    }, [adjustTextareaHeight, sanitizeHebrewInput, scheduleCommit]);
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizeHebrewInput, scheduleCommit]);
 
     const handleDragOver = useCallback((e) => {
         e.preventDefault();


### PR DESCRIPTION
### Motivation
- Prevent multiple queued `requestAnimationFrame` callbacks from conflicting or persisting after unmount when updating the textarea selection range.

### Description
- Introduce `selectionRafRef`, `queueSelectionUpdate`, and `clearSelectionUpdate` to centralize and cancel scheduled selection updates.
- Replace ad-hoc `requestAnimationFrame` calls with `queueSelectionUpdate` in the sanitizer/effect, `handleChange`, `handleKeyDown`, `handlePaste`, `insertTextAtCursor`, and `handleCompositionEnd` paths.
- Ensure cleanup of pending selection RAFs on unmount by invoking `clearSelectionUpdate` and add it to relevant hook dependencies and handlers.

### Testing
- Ran the existing test suite with `npm test` and linters with `npm run lint`, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7b94e7dc8323b605d04f0a2168e6)