### PR TITLE
Queue textarea selection updates with RAF and improve sync/cleanup in MainTextInput

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1889,6 +1889,7 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
     const textareaRef = useRef(null);
     const draftRef = useRef(text);
     const commitTimerRef = useRef(null);
+    const selectionRafRef = useRef(null);
     const dragStateRef = useRef(null);
     const isComposingRef = useRef(false);
     const minTextareaHeightRef = useRef(0);
@@ -1910,6 +1911,20 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         if (commitTimerRef.current !== null) {
             clearTimeout(commitTimerRef.current);
             commitTimerRef.current = null;
+        }
+    }, []);
+
+    const queueSelectionUpdate = useCallback((fn) => {
+        if (selectionRafRef.current !== null) cancelAnimationFrame(selectionRafRef.current);
+        selectionRafRef.current = requestAnimationFrame(() => {
+            selectionRafRef.current = null;
+            fn();
+        });
+    }, []);
+    const clearSelectionUpdate = useCallback(() => {
+        if (selectionRafRef.current !== null) {
+            cancelAnimationFrame(selectionRafRef.current);
+            selectionRafRef.current = null;
         }
     }, []);
 
@@ -1944,12 +1959,22 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
 
     useEffect(() => {
         const sanitized = sanitizeHebrewInput(text);
-        draftRef.current = sanitized;
-
         const textarea = textareaRef.current;
-        if (!textarea || textarea.value === sanitized) return;
+        if (!textarea) {
+            draftRef.current = sanitized;
+            return;
+        }
 
         const isFocused = document.activeElement === textarea;
+        const hasLocalUncommittedChanges = draftRef.current !== sanitized;
+
+        if (isFocused && hasLocalUncommittedChanges) {
+            return;
+        }
+
+        draftRef.current = sanitized;
+        if (textarea.value === sanitized) return;
+
         const selectionStart = textarea.selectionStart ?? sanitized.length;
         const selectionEnd = textarea.selectionEnd ?? sanitized.length;
 
@@ -1957,16 +1982,19 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         if (isFocused) {
             const nextStart = Math.min(selectionStart, sanitized.length);
             const nextEnd = Math.min(selectionEnd, sanitized.length);
-            requestAnimationFrame(() => textarea.setSelectionRange(nextStart, nextEnd));
+            queueSelectionUpdate(() => textarea.setSelectionRange(nextStart, nextEnd));
         }
-    }, [adjustTextareaHeight, sanitizeHebrewInput, text]);
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizeHebrewInput, text]);
 
     useEffect(() => {
         adjustTextareaHeight();
         applyTextareaRowBounds();
     }, [adjustTextareaHeight, applyTextareaRowBounds, textSize]);
 
-    useEffect(() => () => clearCommitTimer(), [clearCommitTimer]);
+    useEffect(() => () => {
+        clearCommitTimer();
+        clearSelectionUpdate();
+    }, [clearCommitTimer, clearSelectionUpdate]);
 
     const scheduleCommit = useCallback((nextValue) => {
         clearCommitTimer();
@@ -2011,13 +2039,13 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
             const cursorStart = e.target.selectionStart ?? rawValue.length;
             const nextCursor = sanitizeHebrewInput(rawValue.slice(0, cursorStart)).length;
             e.target.value = nextValue;
-            requestAnimationFrame(() => e.target.setSelectionRange(nextCursor, nextCursor));
+            queueSelectionUpdate(() => e.target.setSelectionRange(nextCursor, nextCursor));
         }
 
         draftRef.current = nextValue;
         adjustTextareaHeight(e.target);
         scheduleCommit(nextValue);
-    }, [adjustTextareaHeight, sanitizeHebrewInput, scheduleCommit]);
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizeHebrewInput, scheduleCommit]);
 
     const handleKeyDown = useCallback((e) => {
         if (isComposingRef.current || e.nativeEvent?.isComposing) return;
@@ -2042,6 +2070,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         if (isMetaCombo || e.altKey || key === 'shift' || key === 'alt' || key === 'control' || key === 'meta') {
             return;
         }
+
+        clearSelectionUpdate();
 
         if (isEnterKey || isSpaceKey) {
             return;
@@ -2074,14 +2104,14 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
             scheduleCommit(nextValue);
 
             const nextPos = start + mappedLetter.length;
-            requestAnimationFrame(() => textarea.setSelectionRange(nextPos, nextPos));
+            queueSelectionUpdate(() => textarea.setSelectionRange(nextPos, nextPos));
             return;
         }
 
         if (!/^[א-ת]$/i.test(e.key)) {
             e.preventDefault();
         }
-    }, [adjustTextareaHeight, commitChanges, scheduleCommit]);
+    }, [adjustTextareaHeight, clearSelectionUpdate, commitChanges, queueSelectionUpdate, scheduleCommit]);
 
     const handlePaste = useCallback((e) => {
         const pasted = e.clipboardData?.getData('text') ?? '';
@@ -2103,8 +2133,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         scheduleCommit(nextValue);
 
         const nextPos = start + sanitized.length;
-        requestAnimationFrame(() => textarea.setSelectionRange(nextPos, nextPos));
-    }, [adjustTextareaHeight, sanitizePastedHebrewInput, scheduleCommit]);
+        queueSelectionUpdate(() => textarea.setSelectionRange(nextPos, nextPos));
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizePastedHebrewInput, scheduleCommit]);
 
     const insertTextAtCursor = useCallback((incomingText) => {
         const textarea = textareaRef.current;
@@ -2122,8 +2152,8 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
         scheduleCommit(nextValue);
 
         const nextPos = start + sanitized.length;
-        requestAnimationFrame(() => textarea.setSelectionRange(nextPos, nextPos));
-    }, [adjustTextareaHeight, sanitizePastedHebrewInput, scheduleCommit]);
+        queueSelectionUpdate(() => textarea.setSelectionRange(nextPos, nextPos));
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizePastedHebrewInput, scheduleCommit]);
 
 
 
@@ -2139,13 +2169,13 @@ const MainTextInput = memo(({ text, isDarkMode, textSize, onTextChange }) => {
             const cursorStart = e.currentTarget.selectionStart ?? e.currentTarget.value.length;
             const nextCursor = sanitizeHebrewInput(e.currentTarget.value.slice(0, cursorStart)).length;
             e.currentTarget.value = finalizedValue;
-            requestAnimationFrame(() => e.currentTarget.setSelectionRange(nextCursor, nextCursor));
+            queueSelectionUpdate(() => e.currentTarget.setSelectionRange(nextCursor, nextCursor));
         }
 
         draftRef.current = finalizedValue;
         adjustTextareaHeight(e.currentTarget);
         scheduleCommit(finalizedValue);
-    }, [adjustTextareaHeight, sanitizeHebrewInput, scheduleCommit]);
+    }, [adjustTextareaHeight, queueSelectionUpdate, sanitizeHebrewInput, scheduleCommit]);
 
     const handleDragOver = useCallback((e) => {
         e.preventDefault();


### PR DESCRIPTION
### Motivation
- Reduce layout thrash and prevent race conditions when restoring or updating the textarea selection by centralizing selection updates behind a cancelable RAF queue. 
- Avoid overwriting local uncommitted edits when external `text` prop changes while the textarea is focused. 
- Ensure pending RAF callbacks are cancelled on unmount to prevent stale DOM operations. 

### Description
- Add `selectionRafRef`, and two helpers `queueSelectionUpdate` and `clearSelectionUpdate` to schedule/cancel `requestAnimationFrame` selection updates. 
- Replace direct `requestAnimationFrame` calls with `queueSelectionUpdate` across selection-changing code paths including initial sync, `handleChange`, `handleKeyDown`, `handlePaste`, `insertTextAtCursor`, and `handleCompositionEnd`. 
- Update the `text` synchronization effect to handle missing textarea early, avoid clobbering local uncommitted `draftRef` when focused, and only restore selection when appropriate. 
- Add cleanup to cancel both commit timers and pending selection RAF with `clearSelectionUpdate` on unmount and call `clearSelectionUpdate` at the start of key handling. 

### Testing
- Ran unit tests with `yarn test` and all tests passed. 
- Ran linter with `yarn lint` and no issues were reported. 
- Performed a production build with `yarn build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b7b94e7dc8323b605d04f0a2168e6)