### PR TITLE
Fix digital-root distribution to ignore duplicate lexemes

### DIFF
--- a/src/core/analysisCore.js
+++ b/src/core/analysisCore.js
@@ -345,7 +345,6 @@ function computeCoreResults(text, mode) {
             else if (wd.maxLayer === 'T' && lineMaxLayer !== 'H') lineMaxLayer = 'T';
 
             if (!allWordsMap.has(wd.word)) allWordsMap.set(wd.word, wd);
-            drDistribution[wd.dr] += 1;
             wordCounts.set(wd.word, (wordCounts.get(wd.word) || 0) + 1);
         }
 
@@ -384,6 +383,10 @@ function computeCoreResults(text, mode) {
             isPrimeTotals: { U: isPrimeLineU, T: isPrimeLineT, H: isPrimeLineH },
             lineMaxLayer,
         });
+    }
+
+    for (const wordData of allWordsMap.values()) {
+        drDistribution[wordData.dr] += 1;
     }
 
     growSieveTo(Math.max(grandU, grandT, grandH));


### PR DESCRIPTION
### Motivation
- Avoid inflating the digital-root distribution when the same lexeme appears multiple times so that input like `א א א א א א` contributes `1` to its digital root rather than `6`.

### Description
- In `computeCoreResults` the per-token `drDistribution[wd.dr] += 1` was removed and `drDistribution` is now populated by iterating `allWordsMap.values()` after processing so only unique lexemes are counted.

### Testing
- Ran `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f275ed4e4832382f10ef9bc840963)