### PR TITLE
Fix corpus validation in CI by checking out pinned MAM sources and honoring env overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout pinned MAM-parsed source
+        uses: actions/checkout@v4
+        with:
+          repository: bdenckla/MAM-parsed
+          ref: 95f64d734fc2c4fff139a841c0b9961b0193c76f
+          path: upstream/MAM-parsed
+
+      - name: Checkout pinned MAM-basics semantics reference
+        uses: actions/checkout@v4
+        with:
+          repository: bdenckla/MAM-basics
+          ref: 73f8ea3c857cc3c9258500e1ac5a74791d0cf218
+          path: upstream/MAM-basics
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -25,3 +39,6 @@ jobs:
 
       - name: Run quality gates
         run: npm run check
+        env:
+          MAM_PARSED_PATH: ${{ github.workspace }}/upstream/MAM-parsed
+          MAM_BASICS_PATH: ${{ github.workspace }}/upstream/MAM-basics

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ npm run bundle:check
 
 The generator derives the sibling paths from the repository location, so it
 does not contain a username or machine-specific absolute path. `--source`,
-`--basics`, and `--output` may be supplied for an equivalent layout. It does not
+`--basics`, and `--output` may be supplied for an equivalent layout. The
+`MAM_PARSED_PATH` and `MAM_BASICS_PATH` environment variables provide the same
+source-path overrides for `npm run check` and CI environments. It does not
 write to either upstream repository. With identical upstream revisions and
 converter code it emits byte-identical JSON. The provenance file records the
 available Git revisions, MAM `plus` format, converter and corpus schema versions,

--- a/scripts/generate-tanakh-corpus.mjs
+++ b/scripts/generate-tanakh-corpus.mjs
@@ -425,8 +425,8 @@ function stableJson(value, pretty = false) {
 
 function readArguments(argv) {
     const options = {
-        sourcePath: path.join(WORKSPACE_ROOT, 'MAM-parsed'),
-        basicsPath: path.join(WORKSPACE_ROOT, 'MAM-basics'),
+        sourcePath: path.resolve(process.env.MAM_PARSED_PATH || path.join(WORKSPACE_ROOT, 'MAM-parsed')),
+        basicsPath: path.resolve(process.env.MAM_BASICS_PATH || path.join(WORKSPACE_ROOT, 'MAM-basics')),
         outputPath: path.join(REPO_ROOT, 'public', 'corpus'),
         check: false,
     };

--- a/scripts/validate-tanakh-corpus.mjs
+++ b/scripts/validate-tanakh-corpus.mjs
@@ -13,6 +13,8 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
 const WORKSPACE_ROOT = path.resolve(REPO_ROOT, '..');
 const CORPUS_ROOT = path.join(REPO_ROOT, 'public', 'corpus');
+const MAM_PARSED_ROOT = path.resolve(process.env.MAM_PARSED_PATH || path.join(WORKSPACE_ROOT, 'MAM-parsed'));
+const MAM_BASICS_ROOT = path.resolve(process.env.MAM_BASICS_PATH || path.join(WORKSPACE_ROOT, 'MAM-basics'));
 
 function readJson(relativePath) {
     return JSON.parse(fs.readFileSync(path.join(CORPUS_ROOT, relativePath), 'utf8'));
@@ -32,8 +34,8 @@ function allSections() {
 
 test('generated corpus is byte-for-byte deterministic from local siblings', () => {
     const generated = expectedOutput({
-        sourcePath: path.join(WORKSPACE_ROOT, 'MAM-parsed'),
-        basicsPath: path.join(WORKSPACE_ROOT, 'MAM-basics'),
+        sourcePath: MAM_PARSED_ROOT,
+        basicsPath: MAM_BASICS_ROOT,
         outputPath: CORPUS_ROOT,
     });
     for (const [relativePath, expected] of generated.files.entries()) {


### PR DESCRIPTION
### Motivation
- Ensure `npm run check` (corpus generation/validation) can run reliably in CI by making the required upstream MAM sources available to the job and by allowing local/CI overrides for their locations.
- Make the corpus generator and validation tests configurable so they do not assume sibling-repo layout and can run against pinned upstream revisions in CI.

### Description
- Update CI workflow (`.github/workflows/ci.yml`) to `checkout` the pinned `bdenckla/MAM-parsed` and `bdenckla/MAM-basics` revisions and expose their locations via `MAM_PARSED_PATH` and `MAM_BASICS_PATH` environment variables.
- Change `scripts/generate-tanakh-corpus.mjs` so `readArguments` reads `MAM_PARSED_PATH` and `MAM_BASICS_PATH` from the environment while preserving the existing CLI overrides and sibling-directory defaults.
- Update `scripts/validate-tanakh-corpus.mjs` to use the same environment-path overrides for deterministic validation, and adjust test import paths to the script location.
- Document the `MAM_PARSED_PATH`/`MAM_BASICS_PATH` environment variables in the `README.md` for local and CI usage.

### Testing
- Ran `npm run lint` and `npm run typecheck`, both of which passed successfully.
- Built the app with `npm run build`, ran `npm run bundle:check`, and executed `npm run perf:check`, all of which passed successfully.
- Ran the automated test suite (`node --test` for a set of repository tests) with 44 tests passing and zero failures.
- Verified environment overrides by running `MAM_PARSED_PATH=/tmp/custom-parsed MAM_BASICS_PATH=/tmp/custom-basics node -e "import { readArguments } from './scripts/generate-tanakh-corpus.mjs'; ..."` which confirmed the script honors the env vars; however, a full `npm run check` involving cloning the pinned upstream repositories could not be completed locally because the environment blocked fetching the upstream repos (HTTP 403), which the updated CI workflow will address by checking them out inside Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d9f6b20048323a8bd6e6a03334484)